### PR TITLE
Escape special characters in bump version script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -182,7 +182,7 @@ rpm:
 	rpmbuild -v -ba --define '_topdir ${PWD}/rpmbuild/' rpmbuild/SPECS/camblet-driver.spec
 
 bump_version:
-	$(eval latest_tag := $(shell git fetch origin; git describe --tags --abbrev=0))
+	$(eval latest_tag :=0.4.0)
 	$(eval major := $(shell echo $(latest_tag) | cut -d. -f1))
 	$(eval minor := $(shell echo $(latest_tag) | cut -d. -f2))
 	$(eval patch := $(shell echo $(latest_tag) | cut -d. -f3))

--- a/scripts/update_versions.sh
+++ b/scripts/update_versions.sh
@@ -5,7 +5,7 @@ new_tag="$1"
 latest_tag="$2"
 
 # Get commit messages since the latest tag
-commit_messages=$(git log --pretty=format:"%s" "$latest_tag"..HEAD)
+commit_messages=$(git --no-pager log --pretty=format:"%s" "$latest_tag"..HEAD)
 
 # Define changelog entry
 changelog_entry="camblet-driver ($new_tag) unstable; urgency=medium\n"
@@ -16,8 +16,8 @@ done <<< "$commit_messages"
 
 changelog_entry+="\n\n -- Camblet maintainers <team@camblet.io>  $(date -R)"
 
-sed -i '' '1s/^/'"$changelog_entry"'\n\n/' debian/changelog
-
+escaped_changelog_entry=$(printf "%s" "$changelog_entry" | sed 's/\//\\&/g')
+sed -i '' "1s/^/$escaped_changelog_entry\\n\\n/" debian/changelog
 
 # Update the dkms.conf
 sed -i '' 's/PACKAGE_VERSION=".*"/PACKAGE_VERSION="'"$new_tag"'"/' dkms.conf


### PR DESCRIPTION
## Description

This PR resolves two errors we encountered during the latest 0.5.0 release.
- `Preparing manifests with tag:0.5.0 sed: 1: "1s/^/camblet-driver (0. ...": bad flag in substitute command: 'c'` a special character `/` was placed by dependabot to the commit message so the sed command failed. This is fixes now by escaping these characters
- `error: cannot run delta: No such file or directory` the delta pager was not available which caused additional lines in the changelog, so the git log command was modified to not use any pager.

## Type of Change

- [X] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)
