### PR TITLE
connection event tracing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,8 @@ camblet-objs :=  third-party/wasm3/source/m3_api_libc.o \
 			  string.o \
 			  augmentation.o \
 			  config.o \
-			  sd.o
+			  sd.o \
+			  trace.o
 
 # Set the path to the Kernel build utils.
 KBUILD=/lib/modules/$(shell uname -r)/build/

--- a/commands.c
+++ b/commands.c
@@ -35,7 +35,7 @@ static DECLARE_WAIT_QUEUE_HEAD(command_wait_queue);
 // commands that are being processed by the driver
 static LIST_HEAD(in_flight_command_list);
 
-command_answer *this_send_command(char *name, char *data, task_context *context, bool is_message)
+static command_answer *this_send_command(char *name, char *data, task_context *context, bool is_message)
 {
     struct command *cmd = kzalloc(sizeof(struct command), GFP_KERNEL);
 
@@ -97,9 +97,9 @@ command_answer *send_command(char *name, char *data, task_context *context)
 
 // add a message to the command list (to be processed by the driver)
 // this is a non-blocking function
-command_answer *send_message(char *name, char *data, task_context *context)
+void send_message(char *name, char *data, task_context *context)
 {
-    return this_send_command(name, data, context, true);
+    this_send_command(name, data, context, true);
 }
 
 command_answer *send_augment_command()

--- a/commands.c
+++ b/commands.c
@@ -104,9 +104,7 @@ void send_message(char *name, char *data, task_context *context)
 
 command_answer *send_augment_command()
 {
-    command_answer *answer = send_command("augment", NULL, get_task_context());
-
-    return answer;
+    return send_command("augment", NULL, get_task_context());
 }
 
 command_answer *send_accept_command(u16 port)

--- a/commands.h
+++ b/commands.h
@@ -33,6 +33,7 @@ typedef struct csr_sign_answer
 
 void free_command_answer(command_answer *cmd_answer);
 
+command_answer *send_message(char *name, char *data, task_context *context);
 command_answer *send_command(char *name, char *data, task_context *context);
 command_answer *answer_with_error(char *error_message);
 
@@ -50,10 +51,12 @@ typedef struct command
     task_context *context;
     uuid_t uuid;
     struct command_answer *answer;
+    bool is_message;
     wait_queue_head_t wait_queue;
 } command;
 
 command *lookup_in_flight_command(char *id);
 command *get_next_command(void);
+void free_command(command *cmd);
 
 #endif

--- a/commands.h
+++ b/commands.h
@@ -33,7 +33,7 @@ typedef struct csr_sign_answer
 
 void free_command_answer(command_answer *cmd_answer);
 
-command_answer *send_message(char *name, char *data, task_context *context);
+void send_message(char *name, char *data, task_context *context);
 command_answer *send_command(char *name, char *data, task_context *context);
 command_answer *answer_with_error(char *error_message);
 

--- a/opa.h
+++ b/opa.h
@@ -22,7 +22,7 @@ typedef struct
     bool allowed;
     bool mtls;
     bool passthrough;
-
+    char *matched_policy_json;
     char *id;
     char *dns;
     char *uri;

--- a/socket.h
+++ b/socket.h
@@ -12,6 +12,7 @@
 #define socket_h
 
 #include <linux/inet.h>
+#include <linux/uuid.h>
 
 #include "json.h"
 
@@ -26,13 +27,16 @@ typedef enum
 
 typedef struct
 {
+    uuid_t uuid;
     direction direction;
     char source_ip[INET6_ADDRSTRLEN];
     u16 source_port;
+    char source_address[INET6_ADDRSTRLEN + 5];
     char destination_ip[INET6_ADDRSTRLEN];
     u16 destination_port;
-} net_conn_info;
+    char destination_address[INET6_ADDRSTRLEN + 5];
+} tcp_connection_context;
 
-void add_net_conn_info_to_json(net_conn_info conn_info, JSON_Object *json_object);
+void add_net_conn_info_to_json(const tcp_connection_context *ctx, JSON_Object *json_object);
 
 #endif

--- a/socket.h
+++ b/socket.h
@@ -27,7 +27,7 @@ typedef enum
 
 typedef struct
 {
-    uuid_t uuid;
+    u64 id;
     direction direction;
     char source_ip[INET6_ADDRSTRLEN];
     u16 source_port;

--- a/task_context.c
+++ b/task_context.c
@@ -48,7 +48,10 @@ task_context *get_task_context(void)
     context->namespace_ids.cgroup = current->nsproxy->cgroup_ns->ns.inum;
 
     struct css_set *cset = task_css_set(current);
-    cgroup_path(cset->dfl_cgrp, context->cgroup_path, sizeof(context->cgroup_path));
+    if (cset)
+    {
+        cgroup_path(cset->dfl_cgrp, context->cgroup_path, sizeof(context->cgroup_path));
+    }
 
     return context;
 }

--- a/tls.c
+++ b/tls.c
@@ -86,8 +86,6 @@ xwc_end_chain(const br_x509_class **ctx)
     camblet_cc = ((br_x509_camblet_context *)(void *)ctx);
     mini_cc = &camblet_cc->ctx;
 
-    pr_info("xwc_end_chain # uuid[%pUB]", camblet_cc->conn_ctx->uuid.b);
-
     unsigned int err = mini_cc->vtable->end_chain(&mini_cc->vtable);
 
     if (err == BR_ERR_X509_NOT_TRUSTED && camblet_cc->insecure)
@@ -165,8 +163,6 @@ void br_x509_camblet_init(br_x509_camblet_context *ctx, br_ssl_engine_context *e
     ctx->socket_context = socket_context;
     ctx->conn_ctx = conn_ctx;
     ctx->insecure = insecure;
-
-    pr_info("br_x509_camblet_init # uuid[%pUB]", ctx->conn_ctx->uuid.b);
 
     br_name_element *name_elts = kmalloc(sizeof(br_name_element) * 3, GFP_KERNEL);
 

--- a/tls.h
+++ b/tls.h
@@ -13,6 +13,7 @@
 
 #include "bearssl.h"
 #include "opa.h"
+#include "socket.h"
 
 /*
  * This is a wrapper around the BearSSL X.509 validation engine. It
@@ -26,10 +27,11 @@ typedef struct br_x509_camblet_context
     const br_x509_class *vtable;
     br_x509_minimal_context ctx;
     opa_socket_context *socket_context;
+    const tcp_connection_context *conn_ctx;
     bool insecure;
 } br_x509_camblet_context;
 
-void br_x509_camblet_init(br_x509_camblet_context *ctx, br_ssl_engine_context *eng, opa_socket_context *socket_context, bool insecure);
+void br_x509_camblet_init(br_x509_camblet_context *ctx, br_ssl_engine_context *eng, opa_socket_context *socket_context, const tcp_connection_context *conn_ctx, bool insecure);
 void br_x509_camblet_free(br_x509_camblet_context *ctx);
 
 #endif

--- a/trace.c
+++ b/trace.c
@@ -17,6 +17,7 @@
 #include "json.h"
 #include "commands.h"
 #include "socket.h"
+#include "string.h"
 
 // a list to hold trace requests
 static LIST_HEAD(trace_requests);
@@ -314,11 +315,12 @@ int trace_log(const tcp_connection_context *conn_ctx, const char *message, int l
         return -ENOMEM;
     }
 
-    if (!uuid_is_null(&conn_ctx->uuid))
+    if (conn_ctx)
     {
-        char uuid[UUID_STRING_LEN + 1];
-        int uuid_len = snprintf(uuid, UUID_STRING_LEN + 1, "%pUB", conn_ctx->uuid.b);
-        if (uuid_len < 0 || json_object_set_string(root_object, "uuid", uuid) < 0)
+        const char *id_str = strnprintf("%u", conn_ctx->id);
+        int retval = json_object_set_string(root_object, "correlation_id", id_str);
+        kfree(id_str);
+        if (retval < 0)
         {
             json_value_free(root_value);
 

--- a/trace.c
+++ b/trace.c
@@ -1,0 +1,333 @@
+/*
+ * Copyright (c) 2024 Cisco and its affiliates. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT OR GPL-2.0-only
+ *
+ * Licensed under the MIT license <LICENSE.MIT or https://opensource.org/licenses/MIT> or the GPLv2 license
+ * <LICENSE.GPL or https://opensource.org/license/gpl-2-0>, at your option. This file may not be copied,
+ * modified, or distributed except according to those terms.
+ */
+
+#define pr_fmt(fmt) "%s: " fmt, KBUILD_MODNAME
+
+#include <linux/list.h>
+#include <linux/slab.h>
+#include "trace.h"
+#include "task_context.h"
+#include "json.h"
+#include "commands.h"
+
+// a list to hold trace requests
+static LIST_HEAD(trace_requests);
+
+// lock for the above list to make it thread safe
+static DEFINE_MUTEX(trace_requests_lock);
+
+static void lock_trace_requests(void)
+{
+    mutex_lock(&trace_requests_lock);
+}
+
+static void unlock_trace_requests(void)
+{
+    mutex_unlock(&trace_requests_lock);
+}
+
+int add_trace_request(int pid, int uid, const char *command_name)
+{
+    trace_request *tr = kzalloc(sizeof(trace_request), GFP_KERNEL);
+
+    if (!tr)
+    {
+        return -ENOMEM;
+    }
+
+    tr->pid = pid;
+    tr->uid = uid;
+    if (command_name)
+    {
+        strncpy(tr->command_name, command_name, MAX_COMM_LEN);
+    }
+
+    lock_trace_requests();
+    list_add(&tr->list, &trace_requests);
+    unlock_trace_requests();
+
+    return 0;
+}
+
+trace_request *get_trace_request(int pid, int uid, const char *command_name)
+{
+    trace_request *tr;
+
+    lock_trace_requests();
+
+    pr_debug("look for pid[%d] uid[%d] command_name[%s]", pid, uid, command_name);
+
+    list_for_each_entry(tr, &trace_requests, list)
+    {
+        pr_debug("check pid[%d] uid[%d] command_name[%s]", tr->pid, tr->uid, tr->command_name);
+
+        if ((tr->pid > 0 || pid > 0) && tr->pid != pid)
+        {
+            continue;
+        }
+
+        if ((tr->uid >= 0 || uid > 0) && tr->uid != uid)
+        {
+            continue;
+        }
+
+        if ((strlen(tr->command_name) > 0 || command_name) && strcmp(command_name, tr->command_name))
+        {
+            continue;
+        }
+
+        unlock_trace_requests();
+
+        return tr;
+    }
+
+    unlock_trace_requests();
+
+    return 0;
+}
+
+trace_request *get_trace_request_by_partial_match(int pid, int uid, const char *command_name)
+{
+    trace_request *tr;
+
+    lock_trace_requests();
+
+    pr_debug("look for trace request # pid[%d] uid[%d] command_name[%s]", pid, uid, command_name);
+
+    list_for_each_entry(tr, &trace_requests, list)
+    {
+        pr_debug("check trace request # pid[%d] uid[%d] command_name[%s]", tr->pid, tr->uid, tr->command_name);
+
+        if (tr->pid > 0 && tr->pid != pid)
+        {
+            pr_debug("pid continue [%d != %d]", tr->pid, pid);
+            continue;
+        }
+
+        if (tr->uid > 0 && tr->uid != uid)
+        {
+            pr_debug("uid continue [%d != %d]", tr->uid, uid);
+            continue;
+        }
+
+        if (strlen(tr->command_name) > 0 && strcmp(command_name, tr->command_name))
+        {
+            pr_debug("cn continue [%s != %s]", tr->command_name, command_name);
+            continue;
+        }
+
+        unlock_trace_requests();
+
+        return tr;
+    }
+
+    unlock_trace_requests();
+
+    return 0;
+}
+
+static void free_trace_request(trace_request *tr)
+{
+    if (tr)
+    {
+        list_del(&tr->list);
+        kfree(tr);
+    }
+}
+
+void remove_trace_request(trace_request *tr)
+{
+    if (tr)
+    {
+        lock_trace_requests();
+        free_trace_request(tr);
+        unlock_trace_requests();
+    }
+}
+
+void clear_trace_requests()
+{
+    trace_request *tr, *tmp;
+
+    lock_trace_requests();
+
+    list_for_each_entry_safe(tr, tmp, &trace_requests, list)
+    {
+        free_trace_request(tr);
+    }
+
+    unlock_trace_requests();
+}
+
+char *compose_log_message(const char *message, int n, va_list args)
+{
+    int i;
+    va_list args_copy;
+    char *retval;
+
+    va_copy(args_copy, args);
+
+    if (message == NULL || n < 2 || n % 2 != 0)
+    {
+        retval = ERR_PTR(-EINVAL);
+
+        goto out;
+    }
+
+    int size = strlen(message) + 3;
+    for (i = 0; i < n; i++)
+    {
+        char *arg = va_arg(args, const char *);
+        if (arg == NULL)
+        {
+            if (i % 2 == 0)
+            {
+                retval = ERR_PTR(-EINVAL);
+                goto out;
+            }
+            continue;
+        }
+        size += strlen(arg) + 1;
+    }
+
+    char *log_message = kzalloc(size + 1, GFP_KERNEL);
+    if (log_message == NULL)
+    {
+        retval = ERR_PTR(-ENOMEM);
+
+        goto out;
+    }
+
+    sprintf(log_message, "%s", message);
+
+    bool sep = false;
+
+    for (i = 0; i < n; i += 2)
+    {
+        char *var = va_arg(args_copy, const char *);
+        char *value = va_arg(args_copy, const char *);
+        if (var && value)
+        {
+            if (!sep)
+            {
+                sprintf(log_message + strlen(log_message), " # ");
+                sep = true;
+            }
+            sprintf(log_message + strlen(log_message), "%s[%s]", var, value);
+            if (i < n - 2)
+            {
+                strcat(log_message, " ");
+            }
+        }
+    }
+
+    retval = log_message;
+
+out:
+    va_end(args_copy);
+
+    return retval;
+}
+
+int trace_log(const char *message, int log_level, int n, ...)
+{
+    unsigned int i;
+    va_list args, args_copy;
+    char level[8];
+
+    if (n % 2 != 0)
+    {
+        return -EINVAL;
+    }
+
+    if (log_level > 0)
+    {
+        va_start(args, n);
+        va_copy(args_copy, args);
+        char *log_message = compose_log_message(message, n, args_copy);
+        if (IS_ERR(log_message))
+            return PTR_ERR(log_message);
+
+        switch (log_level)
+        {
+        case LOGLEVEL_ERR:
+            pr_err("%s", log_message);
+            strcpy(level, "error");
+            break;
+        case LOGLEVEL_WARNING:
+            pr_warn("%s", log_message);
+            strcpy(level, "warning");
+            break;
+        case LOGLEVEL_INFO:
+            pr_info("%s", log_message);
+            strcpy(level, "info");
+            break;
+        case LOGLEVEL_DEBUG:
+            pr_debug("%s", log_message);
+            strcpy(level, "debug");
+            break;
+        default:
+            printk("%s", log_message);
+        }
+
+        kfree(log_message);
+        va_end(args_copy);
+        va_end(args);
+    }
+
+    task_context *tc = get_task_context();
+    trace_request *tr = get_trace_request_by_partial_match(tc->pid, tc->uid.val, tc->command_name);
+    free_task_context(tc);
+
+    if (tr == NULL)
+    {
+        return 0;
+    }
+
+    JSON_Value *root_value = json_value_init_object();
+    JSON_Object *root_object = json_value_get_object(root_value);
+
+    if (!root_object)
+    {
+        return -ENOMEM;
+    }
+
+    if (json_object_set_string(root_object, "message", message) < 0)
+    {
+        json_value_free(root_value);
+
+        return -ENOMEM;
+    }
+
+    if (log_level > 0 && json_object_set_string(root_object, "level", level) < 0)
+    {
+        json_value_free(root_value);
+
+        return -ENOMEM;
+    }
+
+    va_start(args, n);
+    for (i = 0; i < n; i += 2)
+    {
+        char *var = va_arg(args, const char *);
+        char *value = va_arg(args, const char *);
+        if (var && value && json_object_set_string(root_object, var, value) < 0)
+        {
+            pr_err("could not set json string [%s] [%s]", var, value);
+        }
+    }
+    va_end(args);
+
+    send_message("log", json_serialize_to_string(root_value), get_task_context());
+
+    json_value_free(root_value);
+
+    return 0;
+}

--- a/trace.h
+++ b/trace.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2024 Cisco and its affiliates. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT OR GPL-2.0-only
+ *
+ * Licensed under the MIT license <LICENSE.MIT or https://opensource.org/licenses/MIT> or the GPLv2 license
+ * <LICENSE.GPL or https://opensource.org/license/gpl-2-0>, at your option. This file may not be copied,
+ * modified, or distributed except according to those terms.
+ */
+
+#ifndef trace_h
+#define trace_h
+
+#include <linux/types.h>
+#include "task_context.h"
+
+typedef struct
+{
+    int pid;
+    int uid;
+    char command_name[MAX_COMM_LEN];
+    struct list_head list;
+} trace_request;
+
+int add_trace_request(int pid, int uid, const char *command_name);
+void remove_trace_request(trace_request *params);
+void clear_trace_requests(void);
+trace_request *get_trace_request(int pid, int uid, const char *command_name);
+trace_request *get_trace_request_by_partial_match(int pid, int uid, const char *command_name);
+
+int trace_log(const char *message, int log_level, int n, ...);
+
+#define trace_err(message, n, ...) \
+    trace_log(message, LOGLEVEL_ERR, n, ##__VA_ARGS__);
+
+#define trace_warn(message, n, ...) \
+    trace_log(message, LOGLEVEL_WARNING, n, ##__VA_ARGS__);
+
+#define trace_info(message, n, ...) \
+    trace_log(message, LOGLEVEL_INFO, n, ##__VA_ARGS__);
+
+#define trace_debug(message, n, ...) \
+    trace_log(message, LOGLEVEL_DEBUG, n, ##__VA_ARGS__);
+
+#define trace_msg(message, n, ...) \
+    trace_log(message, -1, n, ##__VA_ARGS__);
+
+#endif

--- a/trace.h
+++ b/trace.h
@@ -13,6 +13,7 @@
 
 #include <linux/types.h>
 #include "task_context.h"
+#include "socket.h"
 
 typedef struct
 {
@@ -28,21 +29,21 @@ void clear_trace_requests(void);
 trace_request *get_trace_request(int pid, int uid, const char *command_name);
 trace_request *get_trace_request_by_partial_match(int pid, int uid, const char *command_name);
 
-int trace_log(const char *message, int log_level, int n, ...);
+int trace_log(const tcp_connection_context *conn_ctx, const char *message, int log_level, int n, ...);
 
-#define trace_err(message, n, ...) \
-    trace_log(message, LOGLEVEL_ERR, n, ##__VA_ARGS__);
+#define trace_err(conn_ctx, message, n, ...) \
+    trace_log(conn_ctx, message, LOGLEVEL_ERR, n, ##__VA_ARGS__);
 
-#define trace_warn(message, n, ...) \
-    trace_log(message, LOGLEVEL_WARNING, n, ##__VA_ARGS__);
+#define trace_warn(conn_ctx, message, n, ...) \
+    trace_log(conn_ctx, message, LOGLEVEL_WARNING, n, ##__VA_ARGS__);
 
-#define trace_info(message, n, ...) \
-    trace_log(message, LOGLEVEL_INFO, n, ##__VA_ARGS__);
+#define trace_info(conn_ctx, message, n, ...) \
+    trace_log(conn_ctx, message, LOGLEVEL_INFO, n, ##__VA_ARGS__);
 
-#define trace_debug(message, n, ...) \
-    trace_log(message, LOGLEVEL_DEBUG, n, ##__VA_ARGS__);
+#define trace_debug(conn_ctx, message, n, ...) \
+    trace_log(conn_ctx, message, LOGLEVEL_DEBUG, n, ##__VA_ARGS__);
 
-#define trace_msg(message, n, ...) \
-    trace_log(message, -1, n, ##__VA_ARGS__);
+#define trace_msg(conn_ctx, message, n, ...) \
+    trace_log(conn_ctx, message, -1, n, ##__VA_ARGS__);
 
 #endif


### PR DESCRIPTION
## Description

Related driver PR [cisco-open/camblet#108]

This PR implements connection event tracing capability.

There is a new entity called `trace request`. The CLI agent is able to register request for UID, PID, command name or a combination for them for tracing events realtime.

The driver send one-way trace messages to the CLI agent based on those requests.

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)
