### PR TITLE
Fix broken smoke-test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,11 +70,11 @@ jobs:
         sudo modprobe camblet
         sudo dmesg -T
 
-    # - name: Setup upterm session
-    #   uses: lhotari/action-upterm@v1
-    #   with:
-    #     ## limits ssh access and adds the ssh public key for the user which triggered the workflow
-    #     limit-access-to-actor: true
+    - name: Setup upterm session
+      uses: lhotari/action-upterm@v1
+      with:
+        ## limits ssh access and adds the ssh public key for the user which triggered the workflow
+        limit-access-to-actor: true
 
     - name: Run proxy-wasm smoke test
       working-directory: camblet-driver

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,11 +70,11 @@ jobs:
         sudo modprobe camblet
         sudo dmesg -T
 
-    - name: Setup upterm session
-      uses: lhotari/action-upterm@v1
-      with:
-        ## limits ssh access and adds the ssh public key for the user which triggered the workflow
-        limit-access-to-actor: true
+    # - name: Setup upterm session
+    #   uses: lhotari/action-upterm@v1
+    #   with:
+    #     ## limits ssh access and adds the ssh public key for the user which triggered the workflow
+    #     limit-access-to-actor: true
 
     - name: Run proxy-wasm smoke test
       working-directory: camblet-driver
@@ -82,7 +82,9 @@ jobs:
       run: |
         touch /tmp/camblet.log /tmp/file-server.log /tmp/python.log
         echo "Run processes"
+        pushd ../camblet
         sudo AGENT_METADATACOLLECTORS_DOCKER_ENABLED=true camblet agent > /tmp/camblet.log &
+        popd
         go run test/file-server.go >/tmp/file-server.log &
         docker run -d --rm -p 8080:80 nginx
         sleep 2


### PR DESCRIPTION
## Description
Camblet agent introduced a new config configuration policy, where the default config dir points to the working directory.
Since the working directory is camblet-driver and not camblet the agent failed to find its config.

## Type of Change

- [X] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)