### PR TITLE
socket: implement automatic TLS passthrough

### DIFF
--- a/commands.c
+++ b/commands.c
@@ -11,7 +11,6 @@
 #define pr_fmt(fmt) "%s: " fmt, KBUILD_MODNAME
 
 #include <linux/slab.h>
-#include <linux/uuid.h>
 #include <linux/inet.h>
 #include <linux/ipv6.h>
 

--- a/socket.c
+++ b/socket.c
@@ -509,7 +509,7 @@ static int ensure_tls_handshake(camblet_socket *s, struct msghdr *msg)
 
 	if (protocol == NULL)
 	{
-		// if we are the client, we have should check if the transport is already encrypted
+		// if we are the client, we should check if the transport is already encrypted
 		if (s->direction == OUTPUT && (s->opa_socket_ctx.passthrough || msghdr_contains_tls_handshake(msg)))
 		{
 			trace_info(conn_ctx, "setting passthrough ALPN", 0);

--- a/socket.h
+++ b/socket.h
@@ -12,7 +12,6 @@
 #define socket_h
 
 #include <linux/inet.h>
-#include <linux/uuid.h>
 
 #include "json.h"
 

--- a/tls.c
+++ b/tls.c
@@ -19,6 +19,33 @@ const unsigned char OID_rfc822Name[] = {0, 1};
 const unsigned char OID_dNSName[] = {0, 2};
 const unsigned char OID_uniformResourceIdentifier[] = {0, 6};
 
+#define tlsHandshakeRecord 22
+#define VersionTLS10 0x0301
+#define VersionTLS11 0x0302
+#define VersionTLS12 0x0303
+#define VersionTLS13 0x0304
+
+bool is_tls_handshake(const uint8_t *b)
+{
+    if (b[0] != tlsHandshakeRecord)
+    {
+        return false;
+    }
+
+    uint16_t tlsVersion = (b[1] << 8) | b[2];
+
+    switch (tlsVersion)
+    {
+    case VersionTLS10:
+    case VersionTLS11:
+    case VersionTLS12:
+    case VersionTLS13:
+        return true;
+    default:
+        return false;
+    }
+}
+
 static int compare_spiffe_ids(const char *allowed_id, const char *id)
 {
     int allowed_id_len = strlen(allowed_id);

--- a/tls.h
+++ b/tls.h
@@ -34,4 +34,6 @@ typedef struct br_x509_camblet_context
 void br_x509_camblet_init(br_x509_camblet_context *ctx, br_ssl_engine_context *eng, opa_socket_context *socket_context, const tcp_connection_context *conn_ctx, bool insecure);
 void br_x509_camblet_free(br_x509_camblet_context *ctx);
 
+bool is_tls_handshake(const uint8_t *b);
+
 #endif


### PR DESCRIPTION
## Description

fixes: #79 

If TLS is detected by the client, it tries to negotiate it with the server side (through ALPN) of Camblet and if they agree, Camblet is not doing double record encryption.

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
