### PR TITLE
support getting connection spiffe ids through socket option

### DIFF
--- a/camblet.h
+++ b/camblet.h
@@ -13,9 +13,6 @@
 
 #define SOL_CAMBLET 7891
 #define CAMBLET_HOSTNAME 1
-
-typedef struct camblet_tls
-{
-} camblet_tls;
+#define CAMBLET_TLS_INFO 2
 
 #endif /* camblet_h */

--- a/camblet.h
+++ b/camblet.h
@@ -15,4 +15,12 @@
 #define CAMBLET_HOSTNAME 1
 #define CAMBLET_TLS_INFO 2
 
+typedef struct
+{
+    bool camblet_enabled;
+    bool mtls_enabled;
+    char spiffe_id[256];
+    char peer_spiffe_id[256];
+} tls_info;
+
 #endif /* camblet_h */

--- a/socket.c
+++ b/socket.c
@@ -966,6 +966,13 @@ int camblet_getsockopt(struct sock *sk, int level,
 		camblet_socket *s = sk->sk_user_data;
 		if (s)
 		{
+			// trigger tls handshake here to avoid timing issues
+			// caused by calling getsockopt before sending anything
+			// through the socket from the client side
+			// there return value here is not important as it will be handled
+			// at the send/recvmsg calls
+			ensure_tls_handshake(s);
+
 			tls_info info = {};
 
 			info.camblet_enabled = s->opa_socket_ctx.allowed;

--- a/socket.c
+++ b/socket.c
@@ -966,11 +966,10 @@ int camblet_getsockopt(struct sock *sk, int level,
 		camblet_socket *s = sk->sk_user_data;
 		if (s)
 		{
-			struct tls_info
-			{
-				char spiffe_id[256];
-				char peer_spiffe_id[256];
-			} info;
+			tls_info info = {};
+
+			info.camblet_enabled = s->opa_socket_ctx.allowed;
+			info.mtls_enabled = s->opa_socket_ctx.mtls;
 
 			if (s->opa_socket_ctx.uri)
 			{

--- a/socket.c
+++ b/socket.c
@@ -481,6 +481,11 @@ static bool camblet_socket_proxywasm_enabled(camblet_socket *s)
 
 static bool msghdr_contains_tls_handshake(struct msghdr *msg)
 {
+	if (msg == NULL)
+	{
+		return false;
+	}
+
 	struct iov_iter *iter = &msg->msg_iter;
 	char first_3_bytes[3];
 	int ret = copy_from_iter(first_3_bytes, 3, iter);

--- a/socket.c
+++ b/socket.c
@@ -971,7 +971,7 @@ int camblet_getsockopt(struct sock *sk, int level,
 			// through the socket from the client side
 			// there return value here is not important as it will be handled
 			// at the send/recvmsg calls
-			ensure_tls_handshake(s);
+			ensure_tls_handshake(s, NULL);
 
 			tls_info info = {};
 

--- a/socket.h
+++ b/socket.h
@@ -34,6 +34,7 @@ typedef struct
     char destination_ip[INET6_ADDRSTRLEN];
     u16 destination_port;
     char destination_address[INET6_ADDRSTRLEN + 5];
+    char *peer_spiffe_id;
 } tcp_connection_context;
 
 void add_net_conn_info_to_json(const tcp_connection_context *ctx, JSON_Object *json_object);

--- a/tls.c
+++ b/tls.c
@@ -12,6 +12,7 @@
 
 #include "tls.h"
 #include "trace.h"
+#include "string.h"
 
 #include <linux/slab.h>
 
@@ -143,6 +144,11 @@ xwc_end_chain(const br_x509_class **ctx)
 
         if (mini_cc->name_elts[i].oid == OID_uniformResourceIdentifier)
         {
+            if (camblet_cc->conn_ctx->peer_spiffe_id == NULL && mini_cc->name_elts[i].buf != NULL)
+            {
+                camblet_cc->conn_ctx->peer_spiffe_id = strdup(mini_cc->name_elts[i].buf);
+            }
+
             spiffe_id = mini_cc->name_elts[i].buf;
             for (k = 0; k < camblet_cc->socket_context->allowed_spiffe_ids_length; k++)
             {
@@ -184,7 +190,7 @@ static const br_x509_class x509_camblet_vtable = {
     xwc_get_pkey,
 };
 
-void br_x509_camblet_init(br_x509_camblet_context *ctx, br_ssl_engine_context *eng, opa_socket_context *socket_context, const tcp_connection_context *conn_ctx, bool insecure)
+void br_x509_camblet_init(br_x509_camblet_context *ctx, br_ssl_engine_context *eng, opa_socket_context *socket_context, tcp_connection_context *conn_ctx, bool insecure)
 {
     ctx->vtable = &x509_camblet_vtable;
     ctx->socket_context = socket_context;

--- a/tls.h
+++ b/tls.h
@@ -27,11 +27,11 @@ typedef struct br_x509_camblet_context
     const br_x509_class *vtable;
     br_x509_minimal_context ctx;
     opa_socket_context *socket_context;
-    const tcp_connection_context *conn_ctx;
+    tcp_connection_context *conn_ctx;
     bool insecure;
 } br_x509_camblet_context;
 
-void br_x509_camblet_init(br_x509_camblet_context *ctx, br_ssl_engine_context *eng, opa_socket_context *socket_context, const tcp_connection_context *conn_ctx, bool insecure);
+void br_x509_camblet_init(br_x509_camblet_context *ctx, br_ssl_engine_context *eng, opa_socket_context *socket_context, tcp_connection_context *conn_ctx, bool insecure);
 void br_x509_camblet_free(br_x509_camblet_context *ctx);
 
 bool is_tls_handshake(const uint8_t *b);


### PR DESCRIPTION
## Description

Introduce new socket option (CAMBLET_TLS_INFO) to get local and peer SPIFFE IDs for a connection.

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)
