### PR TITLE
Handle TLS control messages in case of kTLS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,11 +70,11 @@ jobs:
         sudo modprobe camblet
         sudo dmesg -T
 
-    # - name: Setup upterm session
-    #   uses: lhotari/action-upterm@v1
-    #   with:
-    #     ## limits ssh access and adds the ssh public key for the user which triggered the workflow
-    #     limit-access-to-actor: true
+    - name: Setup upterm session
+      uses: lhotari/action-upterm@v1
+      with:
+        ## limits ssh access and adds the ssh public key for the user which triggered the workflow
+        limit-access-to-actor: true
 
     - name: Run proxy-wasm smoke test
       working-directory: camblet-driver

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,11 +70,11 @@ jobs:
         sudo modprobe camblet
         sudo dmesg -T
 
-    - name: Setup upterm session
-      uses: lhotari/action-upterm@v1
-      with:
-        ## limits ssh access and adds the ssh public key for the user which triggered the workflow
-        limit-access-to-actor: true
+    # - name: Setup upterm session
+    #   uses: lhotari/action-upterm@v1
+    #   with:
+    #     ## limits ssh access and adds the ssh public key for the user which triggered the workflow
+    #     limit-access-to-actor: true
 
     - name: Run proxy-wasm smoke test
       working-directory: camblet-driver

--- a/socket.c
+++ b/socket.c
@@ -126,6 +126,8 @@ struct camblet_socket
 	camblet_recvmsg_t *recvmsg;
 
 	tcp_connection_context *conn_ctx;
+
+	bool handshake_completed;
 };
 
 static int get_read_buffer_capacity(camblet_socket *s);
@@ -318,7 +320,7 @@ static void camblet_socket_free(camblet_socket *s)
 			proxywasm_unlock(s->p);
 		}
 
-		if (s->alpn && !s->ktls_sendmsg && !s->opa_socket_ctx.passthrough)
+		if (s->alpn && !s->opa_socket_ctx.passthrough)
 		{
 			// This call runs the SSL closure protocol (sending a close_notify, receiving the response close_notify).
 			if (br_sslio_close(&s->ioc) != BR_ERR_OK)
@@ -400,6 +402,7 @@ static camblet_socket *camblet_new_server_socket(struct sock *sock, opa_socket_c
 	s->parameters = kzalloc(sizeof(csr_parameters), GFP_KERNEL);
 	s->read_buffer = buffer_new(16 * 1024);
 	s->write_buffer = buffer_new(16 * 1024);
+	s->handshake_completed = false;
 
 	s->sock = sock;
 	s->opa_socket_ctx = opa_socket_ctx;
@@ -962,8 +965,25 @@ static int configure_ktls_sock(camblet_socket *s)
 
 	WRITE_ONCE(s->sock->sk_prot, ktls_prot);
 
-	s->sendmsg = ktls_sendmsg;
-	s->recvmsg = ktls_recvmsg;
+	if (ktls_available)
+	{
+		// By default, BearSSL does not support sending application data without encryption.
+		// To use kTLS, we need unencrypted data, but we also want to receive all the features (e.g., control messages).
+		// Since the first part of the SSL handshake occurs without encryption, BearSSL has a struct called clear.
+		// The clear struct is used for outgoing data, so it only includes encryption and plaintext functions.
+		// For the decryption part and during the handshake, it utilizes a flag called 'incrypt', which is set to 1 once the handshake reaches that stage.
+
+		// Since the handshake is complete, we can utilize the clear struct for outgoing data, and kTLS will handle encryption.
+		// Similarly, we can disable decryption by setting the 'incrypt' field to 0 for the same reason.
+
+		br_ssl_engine_context *ec = get_ssl_engine_context(s);
+		ec->out.vtable = &br_sslrec_out_clear_vtable;
+		ec->incrypt = 0;
+		s->handshake_completed= true;
+	}
+
+	s->sendmsg = bearssl_sendmsg;
+	s->recvmsg = bearssl_recvmsg;
 
 	trace_debug(s->conn_ctx, "kTLS configured", 0);
 
@@ -1444,7 +1464,15 @@ cleanup:
 static int br_low_read(void *ctx, unsigned char *buf, size_t len)
 {
 	camblet_socket *s = (camblet_socket *)ctx;
-	int ret = plain_recvmsg(s, buf, len, 0);
+	int ret = 0;
+	if (s->handshake_completed && ktls_available)
+	{
+		ret = ktls_recvmsg(s, buf, len, 0);
+	}
+	else
+	{
+		ret = plain_recvmsg(s, buf, len, 0);
+	}
 	// BearSSL doesn't like 0 return value, but it's not an error
 	// so we return -1 instead and set sock_closed to true to
 	// indicate that the socket is closed without errors.
@@ -1461,7 +1489,8 @@ static int br_low_read(void *ctx, unsigned char *buf, size_t len)
  */
 static int br_low_write(void *ctx, const unsigned char *buf, size_t len)
 {
-	return plain_sendmsg((camblet_socket *)ctx, buf, len);
+	camblet_socket *s = (camblet_socket *)ctx;
+	return s->handshake_completed && ktls_available ? ktls_sendmsg(s, buf, len) : plain_sendmsg(s, buf, len);
 }
 
 opa_socket_context enriched_socket_eval(const tcp_connection_context *conn_ctx, direction direction, struct sock *sk, int port)


### PR DESCRIPTION
## Description
kTLS is now able to handle TLS control messages relying on bearSSL.
Fixes #60 

## Type of Change

- [ ] Bug Fix
- [X] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)