### PR TITLE
proper and verbose wasm module error printing

### DIFF
--- a/device_driver.c
+++ b/device_driver.c
@@ -169,7 +169,7 @@ wasm_vm_result load_module(const char *name, const char *code, unsigned length, 
             result = init_opa_for(vm, module);
             if (result.err)
             {
-                pr_crit("could not init opa module # err[%s]", result.err);
+                pr_crit("could not init opa module # err[%s: %s]", result.err, wasm_vm_last_error(module));
                 wasm_vm_unlock(vm);
                 return result;
             }
@@ -180,7 +180,7 @@ wasm_vm_result load_module(const char *name, const char *code, unsigned length, 
             result = init_proxywasm_for(vm, module);
             if (result.err)
             {
-                pr_crit("could not init proxywasm module # err[%s]", result.err);
+                pr_crit("could not init proxywasm module # err[%s: %s]", result.err, wasm_vm_last_error(module));
                 wasm_vm_unlock(vm);
                 return result;
             }

--- a/opa.c
+++ b/opa.c
@@ -656,7 +656,7 @@ opa_socket_context this_cpu_opa_socket_eval(const char *input)
     result = opa_eval(opa, inputAddr, inputLen, opa->dataValueAddr, heapAddr);
     if (result.err)
     {
-        pr_crit("opa eval error # name[%s] err[%s]", opa->eval->module->name, result.err);
+        pr_crit("opa eval error # name[%s] err[%s: %s]", opa->eval->module->name, result.err, wasm_vm_last_error(opa->eval->module));
         goto cleanup;
     }
 

--- a/proxywasm.c
+++ b/proxywasm.c
@@ -24,20 +24,23 @@
 #define hash_for_each_possible(name, obj, member, key, bits) \
     hlist_for_each_entry(obj, &name[hash_min(key, bits)], member)
 
-#define FOR_ALL_FILTERS(CALL)                                                          \
-    wasm_vm_result result;                                                             \
-    proxywasm_filter *f;                                                               \
-    for (f = p->filters; f != NULL; f = f->next)                                       \
-    {                                                                                  \
-        pr_info("camblet: calling %s " #CALL, f->name);                                \
-        result = CALL;                                                                 \
-        if (result.err != NULL)                                                        \
-        {                                                                              \
-            pr_err("camblet: calling %s " #CALL " error: %s\n", f->name, result.err);  \
-            return result;                                                             \
-        }                                                                              \
-        pr_info("camblet: result of calling %s " #CALL ": %d", f->name, result.data->i32); \
-    }                                                                                  \
+#define FOR_ALL_FILTERS(CALL)                                              \
+    wasm_vm_result result;                                                 \
+    proxywasm_filter *f;                                                   \
+    for (f = p->filters; f != NULL; f = f->next)                           \
+    {                                                                      \
+        pr_info("camblet: calling %s " #CALL, f->name);                    \
+        result = CALL;                                                     \
+        if (result.err != NULL)                                            \
+        {                                                                  \
+            pr_err("camblet: calling %s " #CALL " # err[%s: %s]", f->name, \
+                   result.err,                                             \
+                   wasm_vm_last_error(f->proxy_on_vm_start->module));      \
+            return result;                                                 \
+        }                                                                  \
+        pr_info("camblet: result of calling %s " #CALL ": %d", f->name,    \
+                result.data->i32);                                         \
+    }                                                                      \
     return result;
 
 typedef struct property_h_node

--- a/proxywasm.c
+++ b/proxywasm.c
@@ -29,11 +29,11 @@
     proxywasm_filter *f;                                                               \
     for (f = p->filters; f != NULL; f = f->next)                                       \
     {                                                                                  \
-        pr_info("camblet: calling %s " #CALL, f->name);                                    \
+        pr_info("camblet: calling %s " #CALL, f->name);                                \
         result = CALL;                                                                 \
         if (result.err != NULL)                                                        \
         {                                                                              \
-            pr_err("camblet: calling %s " #CALL " error: %s\n", f->name, result.err);     \
+            pr_err("camblet: calling %s " #CALL " error: %s\n", f->name, result.err);  \
             return result;                                                             \
         }                                                                              \
         pr_info("camblet: result of calling %s " #CALL ": %d", f->name, result.data->i32); \
@@ -464,7 +464,7 @@ error:
     result = wasm_vm_call_direct(vm, filter->proxy_on_context_create, proxywasm->root_context->id, 0);
     if (result.err)
     {
-        pr_crit("proxy_on_context_create for module %s failed: %s -> %s", module->name, result.err, wasm_vm_last_error(module));
+        pr_crit("proxy_on_context_create for module %s failed # err[%s: %s]", module->name, result.err, wasm_vm_last_error(module));
         kfree(proxywasm);
         return result;
     }
@@ -472,7 +472,7 @@ error:
     result = wasm_vm_call_direct(vm, filter->proxy_on_vm_start, proxywasm->root_context->id, 0);
     if (result.err)
     {
-        pr_crit("proxy_on_vm_start for module %s failed: %s", module->name, result.err);
+        pr_crit("proxy_on_vm_start for module %s failed # err[%s: %s]", module->name, result.err, wasm_vm_last_error(module));
         kfree(proxywasm);
         return result;
     }
@@ -482,7 +482,7 @@ error:
     result = wasm_vm_call_direct(vm, filter->proxy_on_configure, proxywasm->root_context->id, plugin_configuration_size);
     if (result.err)
     {
-        pr_crit("proxy_on_configure for module %s failed: %s", module->name, result.err);
+        pr_crit("proxy_on_configure for module %s failed # err[%s: %s]", module->name, result.err, wasm_vm_last_error(module));
         kfree(proxywasm);
         return result;
     }
@@ -520,13 +520,13 @@ wasm_vm_result proxywasm_destroy_context(proxywasm *p)
         result = wasm_vm_call_direct(p->vm, f->proxy_on_done, p->current_context->id);
         if (result.err != NULL)
         {
-            pr_err("camblet: calling %s.proxy_on_done errored %s", f->name, result.err);
+            pr_err("camblet: calling %s.proxy_on_done errored # err[%s: %s]", f->name, result.err, wasm_vm_last_error(f->proxy_on_done->module));
         }
 
         result = wasm_vm_call_direct(p->vm, f->proxy_on_delete, p->current_context->id);
         if (result.err != NULL)
         {
-            pr_err("camblet: calling %s.proxy_on_delete errored %s", f->name, result.err);
+            pr_err("camblet: calling %s.proxy_on_delete errored # err[%s: %s]", f->name, result.err, wasm_vm_last_error(f->proxy_on_delete->module));
         }
     }
 


### PR DESCRIPTION
## Description

Report underlying dynamic error in case of wasm module compiling loading at all places. Currently we report only the constant error identifier (in C this is the way).

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
