### PR TITLE
ci: use build matrix to test on 6.5 and 5.15 kernel as well

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,8 +7,11 @@ on:
 
 jobs:
   build:
+    strategy:
+      matrix:
+        os: [ubuntu-22.04, ubuntu-20.04]
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
 
     steps:
     - uses: actions/checkout@v4

--- a/socket.c
+++ b/socket.c
@@ -129,7 +129,6 @@ struct camblet_socket
 
 	camblet_sendmsg_t *br_low_sendmsg;
 	camblet_recvmsg_t *br_low_recvmsg;
-
 };
 
 static int get_read_buffer_capacity(camblet_socket *s);
@@ -531,10 +530,10 @@ static int ensure_tls_handshake(camblet_socket *s, struct msghdr *msg)
 			br_ssl_client_reset(s->cc, s->hostname, false);
 		}
 
-		// Initialize the low_read and low_write functions 
-	 	// with tcp_sendmsg and recvmsg. These will be used 
+		// Initialize the low_read and low_write functions
+		// with tcp_sendmsg and recvmsg. These will be used
 		// by BearSSL to read and write data to socket.
-		s->br_low_recvmsg = plain_recvmsg; 
+		s->br_low_recvmsg = plain_recvmsg;
 		s->br_low_sendmsg = plain_sendmsg;
 
 		ret = br_sslio_flush(&s->ioc);
@@ -986,8 +985,8 @@ static int configure_ktls_sock(camblet_socket *s)
 		br_ssl_engine_context *ec = get_ssl_engine_context(s);
 		ec->out.vtable = &br_sslrec_out_clear_vtable;
 		ec->incrypt = 0;
-		s->br_low_recvmsg=ktls_recvmsg;
-		s->br_low_sendmsg=ktls_sendmsg;
+		s->br_low_recvmsg = ktls_recvmsg;
+		s->br_low_sendmsg = ktls_sendmsg;
 	}
 
 	s->sendmsg = bearssl_sendmsg;
@@ -1074,6 +1073,7 @@ int camblet_getsockopt(struct sock *sk, int level,
 	switch (optname)
 	{
 	case CAMBLET_TLS_INFO:
+	{
 		camblet_socket *s = sk->sk_user_data;
 		if (s)
 		{
@@ -1107,6 +1107,7 @@ int camblet_getsockopt(struct sock *sk, int level,
 				return -EFAULT;
 		}
 		return 0;
+	}
 	}
 
 out:


### PR DESCRIPTION
## Description

Introduce a basic matrix build, so we test on ubuntu 22.04 (kernel 6.5) and on 20.04 (kernel 5.15) as well.

## Type of Change

- [x] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
