### PR TITLE
Revert "Handle TLS control messages in case of kTLS (#170)"

### DIFF
--- a/socket.c
+++ b/socket.c
@@ -126,10 +126,6 @@ struct camblet_socket
 	camblet_recvmsg_t *recvmsg;
 
 	tcp_connection_context *conn_ctx;
-
-	camblet_sendmsg_t *br_low_sendmsg;
-	camblet_recvmsg_t *br_low_recvmsg;
-
 };
 
 static int get_read_buffer_capacity(camblet_socket *s);
@@ -322,7 +318,7 @@ static void camblet_socket_free(camblet_socket *s)
 			proxywasm_unlock(s->p);
 		}
 
-		if (s->alpn && !s->opa_socket_ctx.passthrough)
+		if (s->alpn && !s->ktls_sendmsg && !s->opa_socket_ctx.passthrough)
 		{
 			// This call runs the SSL closure protocol (sending a close_notify, receiving the response close_notify).
 			if (br_sslio_close(&s->ioc) != BR_ERR_OK)
@@ -530,12 +526,6 @@ static int ensure_tls_handshake(camblet_socket *s, struct msghdr *msg)
 			br_ssl_engine_set_protocol_names(&s->sc->eng, ALPNs_passthrough, ALPNs_passthrough_NUM);
 			br_ssl_client_reset(s->cc, s->hostname, false);
 		}
-
-		// Initialize the low_read and low_write functions 
-	 	// with tcp_sendmsg and recvmsg. These will be used 
-		// by BearSSL to read and write data to socket.
-		s->br_low_recvmsg = plain_recvmsg; 
-		s->br_low_sendmsg = plain_sendmsg;
 
 		ret = br_sslio_flush(&s->ioc);
 		if (ret == 0)
@@ -972,26 +962,8 @@ static int configure_ktls_sock(camblet_socket *s)
 
 	WRITE_ONCE(s->sock->sk_prot, ktls_prot);
 
-	if (ktls_available)
-	{
-		// By default, BearSSL does not support sending application data without encryption.
-		// To use kTLS, we need unencrypted data, but we also want to receive all the features (e.g., control messages).
-		// Since the first part of the SSL handshake occurs without encryption, BearSSL has a struct called clear.
-		// The clear struct is used for outgoing data, so it only includes encryption and plaintext functions.
-		// For the decryption part and during the handshake, it utilizes a flag called 'incrypt', which is set to 1 once the handshake reaches that stage.
-
-		// Since the handshake is complete, we can utilize the clear struct for outgoing data, and kTLS will handle encryption.
-		// Similarly, we can disable decryption by setting the 'incrypt' field to 0 for the same reason.
-
-		br_ssl_engine_context *ec = get_ssl_engine_context(s);
-		ec->out.vtable = &br_sslrec_out_clear_vtable;
-		ec->incrypt = 0;
-		s->br_low_recvmsg=ktls_recvmsg;
-		s->br_low_sendmsg=ktls_sendmsg;
-	}
-
-	s->sendmsg = bearssl_sendmsg;
-	s->recvmsg = bearssl_recvmsg;
+	s->sendmsg = ktls_sendmsg;
+	s->recvmsg = ktls_recvmsg;
 
 	trace_debug(s->conn_ctx, "kTLS configured", 0);
 
@@ -1472,7 +1444,7 @@ cleanup:
 static int br_low_read(void *ctx, unsigned char *buf, size_t len)
 {
 	camblet_socket *s = (camblet_socket *)ctx;
-	int ret = s->br_low_recvmsg(s, buf, len, 0);
+	int ret = plain_recvmsg(s, buf, len, 0);
 	// BearSSL doesn't like 0 return value, but it's not an error
 	// so we return -1 instead and set sock_closed to true to
 	// indicate that the socket is closed without errors.
@@ -1489,8 +1461,7 @@ static int br_low_read(void *ctx, unsigned char *buf, size_t len)
  */
 static int br_low_write(void *ctx, const unsigned char *buf, size_t len)
 {
-	camblet_socket *s = (camblet_socket *)ctx;
-	return s->br_low_sendmsg(s, buf, len);
+	return plain_sendmsg((camblet_socket *)ctx, buf, len);
 }
 
 opa_socket_context enriched_socket_eval(const tcp_connection_context *conn_ctx, direction direction, struct sock *sk, int port)


### PR DESCRIPTION
This reverts commit d9e8420b030f7fe96cec6b509a856e13ea0b85a6.

## Description

Currently this is broken on 5.15 x86

See various runs of: https://github.com/cisco-open/camblet-driver/pull/182

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
