### PR TITLE
handle -ERESTARTSYS during TLS handshake

### DIFF
--- a/.github/actions/smoketest/action.yaml
+++ b/.github/actions/smoketest/action.yaml
@@ -11,42 +11,11 @@ runs:
         touch /tmp/camblet.log /tmp/file-server.log /tmp/python.log
         echo "Run processes"
         sudo AGENT_METADATACOLLECTORS_DOCKER_ENABLED=true camblet agent > /tmp/camblet.log &
-        go build test/file-server.go
-        ./file-server >/tmp/file-server.log &
-        docker run -d --rm -p 8080:80 nginx
-        sleep 2
 
-        echo "Test downloading a bigger file"
-        head -c 2M </dev/urandom > bigfile.o
-        curl -v -o /tmp/bigfile_downloaded.o http://localhost:8000/bigfile.o
+        ./test/smoke.sh
 
-        echo "Test uploading this file"
-        curl -v -F "bigfile_downloaded.o=@/tmp/bigfile_downloaded.o" http://localhost:8000/upload
-        diff bigfile.o bigfile_downloaded.o
-
-        echo "Test bearssl with non-bearssl compatibility"
-        python3 -m http.server 7000 >/tmp/python.log &
-        sleep 1
-        echo "testing with curl..."
-        curl -k -v https://localhost:7000/
-        echo "testing with wget..."
-        wget --no-check-certificate https://localhost:7000/
-
-        echo "Test openssl client connect to python with default cipher"
-        openssl s_client -connect 127.0.0.1:7000
-        echo "Test openssl client connect to python with ECDHE-RSA-CHACHA20-POLY1305 cipher"
-        openssl s_client -cipher ECDHE-RSA-CHACHA20-POLY1305 -connect 127.0.0.1:7000
-
-        echo "Test sendfile with NGiNX using curl"
-        curl -v http://localhost:8080
-
-        echo "Test sendfile with NGiNX using wget"
-        wget -v http://localhost:8000
-
-        echo "Stop processes"
-        sudo kill -9 $(jobs -p)
+        echo "Stop camblet"
         sudo pkill -9 camblet
-        docker kill $(docker ps -q)
 
     - name: Kernel log
       if: always()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,7 +70,7 @@ jobs:
       working-directory: camblet-driver 
       run: |
         sudo modprobe tls
-        sudo modprobe camblet ktls_available=1
+        sudo modprobe camblet dyndbg==_ ktls_available=1
         sudo dmesg -T
 
     # - name: Setup upterm session
@@ -91,7 +91,7 @@ jobs:
       working-directory: camblet-driver 
       run: |
         sudo rmmod tls
-        sudo modprobe camblet ktls_available=0
+        sudo modprobe camblet dyndbg==_ ktls_available=0
         sudo dmesg -T
 
     - name: Run proxy-wasm smoke test with bearSSL


### PR DESCRIPTION
## Description

This PR fixes `-ERESTARTSYS` retval  during TLS handshake and propagates `-EINTR` up to userspace if the socket is not shutdown, previously it was not handled at all, which caused interrupted handshakes in some cases.

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)
