### PR TITLE
Support aes gcm and ccm ciphers

### DIFF
--- a/socket.c
+++ b/socket.c
@@ -888,16 +888,15 @@ static int configure_ktls_sock(camblet_socket *s)
 	br_ssl_engine_context *eng = get_ssl_engine_context(s);
 	br_ssl_session_parameters *params = &eng->session;
 
-	if ((params->cipher_suite != BR_TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256 &&
-		params->cipher_suite != BR_TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 &&
-		params->cipher_suite != BR_TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 &&
-		params->cipher_suite != BR_TLS_RSA_WITH_AES_128_CCM) ||
-		!ktls_available)
+	if ( !is_cipher_supported(params->cipher_suite) || !ktls_available)
 	{
 		if (!ktls_available)
 			pr_warn("configure kTLS error: kTLS is not available on this system # command[%s]", current->comm);
 		else
-			pr_warn("configure kTLS error: only ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256 cipher suite is supported # requested_suite[%x]", params->cipher_suite);
+			pr_warn("configure kTLS error: only ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256, "
+				"BR_TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, "
+				"BR_TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384, "
+				"BR_TLS_RSA_WITH_AES_128_CCM cipher suites are supported # requested_suite[%x]", params->cipher_suite);
 
 		s->sendmsg = bearssl_sendmsg;
 		s->recvmsg = bearssl_recvmsg;

--- a/socket.c
+++ b/socket.c
@@ -894,9 +894,9 @@ static int configure_ktls_sock(camblet_socket *s)
 			pr_warn("configure kTLS error: kTLS is not available on this system # command[%s]", current->comm);
 		else
 			pr_warn("configure kTLS error: only ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256, "
-					"BR_TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, "
-					"BR_TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384, "
-					"BR_TLS_RSA_WITH_AES_128_CCM cipher suites are supported # requested_suite[%x]",
+					"ECDHE_RSA_WITH_AES_128_GCM_SHA256, "
+					"ECDHE_RSA_WITH_AES_256_GCM_SHA384, "
+					"RSA_WITH_AES_128_CCM cipher suites are supported # requested_suite[%x]",
 					params->cipher_suite);
 
 		s->sendmsg = bearssl_sendmsg;
@@ -945,14 +945,14 @@ static int configure_ktls_sock(camblet_socket *s)
 		return ret;
 	}
 
-	ret = s->sock->sk_prot->setsockopt(s->sock, SOL_TLS, TLS_TX, KERNEL_SOCKPTR(&crypto_info_tx.cipher_type), crypto_info_tx.cipher_type_len);
+	ret = s->sock->sk_prot->setsockopt(s->sock, SOL_TLS, TLS_TX, KERNEL_SOCKPTR(&crypto_info_tx.cipher), crypto_info_tx.cipher_type_len);
 	if (ret != 0)
 	{
 		pr_err("could not set sockopt TLS_TX # command[%s] err[%d]", current->comm, ret);
 		return ret;
 	}
 
-	ret = s->sock->sk_prot->setsockopt(s->sock, SOL_TLS, TLS_RX, KERNEL_SOCKPTR(&crypto_info_rx.cipher_type), crypto_info_rx.cipher_type_len);
+	ret = s->sock->sk_prot->setsockopt(s->sock, SOL_TLS, TLS_RX, KERNEL_SOCKPTR(&crypto_info_rx.cipher), crypto_info_rx.cipher_type_len);
 	if (ret != 0)
 	{
 		pr_err("could not set sockopt TLS_RX # command[%s] err[%d]", current->comm, ret);

--- a/socket.c
+++ b/socket.c
@@ -888,15 +888,16 @@ static int configure_ktls_sock(camblet_socket *s)
 	br_ssl_engine_context *eng = get_ssl_engine_context(s);
 	br_ssl_session_parameters *params = &eng->session;
 
-	if ( !is_cipher_supported(params->cipher_suite) || !ktls_available)
+	if (!is_cipher_supported(params->cipher_suite) || !ktls_available)
 	{
 		if (!ktls_available)
 			pr_warn("configure kTLS error: kTLS is not available on this system # command[%s]", current->comm);
 		else
 			pr_warn("configure kTLS error: only ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256, "
-				"BR_TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, "
-				"BR_TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384, "
-				"BR_TLS_RSA_WITH_AES_128_CCM cipher suites are supported # requested_suite[%x]", params->cipher_suite);
+					"BR_TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, "
+					"BR_TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384, "
+					"BR_TLS_RSA_WITH_AES_128_CCM cipher suites are supported # requested_suite[%x]",
+					params->cipher_suite);
 
 		s->sendmsg = bearssl_sendmsg;
 		s->recvmsg = bearssl_recvmsg;
@@ -912,25 +913,25 @@ static int configure_ktls_sock(camblet_socket *s)
 
 	switch (params->cipher_suite)
 	{
-		case BR_TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256:
-			setup_chacha_poly_crypto_info(&crypto_info_tx, eng->out.chapol.iv, eng->out.chapol.key, eng->out.chapol.seq);
-			setup_chacha_poly_crypto_info(&crypto_info_rx, eng->in.chapol.iv, eng->in.chapol.key, eng->in.chapol.seq);
-			break;
-		case BR_TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256:
-			setup_aes_gcm_128_crypto_info(&crypto_info_tx, eng->out.gcm.iv, eng->out.gcm.key, eng->out.gcm.seq);
-			setup_aes_gcm_128_crypto_info(&crypto_info_rx, eng->in.gcm.iv, eng->in.gcm.key, eng->in.gcm.seq);
-			break;
-		case BR_TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384:
-			setup_aes_gcm_256_crypto_info(&crypto_info_tx, eng->out.gcm.iv, eng->out.gcm.key, eng->out.gcm.seq);
-			setup_aes_gcm_256_crypto_info(&crypto_info_rx, eng->in.gcm.iv, eng->in.gcm.key, eng->in.gcm.seq);
-			break;
-		case BR_TLS_RSA_WITH_AES_128_CCM:
-			setup_aes_ccm_128_crypto_info(&crypto_info_tx, eng->out.ccm.iv, eng->out.ccm.key, eng->out.ccm.seq);
-			setup_aes_ccm_128_crypto_info(&crypto_info_rx, eng->in.ccm.iv, eng->in.ccm.key, eng->in.ccm.seq);
-			break;
-		default:
-			pr_err("cipher %x is not supported with kTLS # command[%s]", params->cipher_suite, current->comm);
-			return -1;
+	case BR_TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256:
+		setup_chacha_poly_crypto_info(&crypto_info_tx, eng->out.chapol.iv, eng->out.chapol.key, eng->out.chapol.seq);
+		setup_chacha_poly_crypto_info(&crypto_info_rx, eng->in.chapol.iv, eng->in.chapol.key, eng->in.chapol.seq);
+		break;
+	case BR_TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256:
+		setup_aes_gcm_128_crypto_info(&crypto_info_tx, eng->out.gcm.iv, eng->out.gcm.key, eng->out.gcm.seq);
+		setup_aes_gcm_128_crypto_info(&crypto_info_rx, eng->in.gcm.iv, eng->in.gcm.key, eng->in.gcm.seq);
+		break;
+	case BR_TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384:
+		setup_aes_gcm_256_crypto_info(&crypto_info_tx, eng->out.gcm.iv, eng->out.gcm.key, eng->out.gcm.seq);
+		setup_aes_gcm_256_crypto_info(&crypto_info_rx, eng->in.gcm.iv, eng->in.gcm.key, eng->in.gcm.seq);
+		break;
+	case BR_TLS_RSA_WITH_AES_128_CCM:
+		setup_aes_ccm_128_crypto_info(&crypto_info_tx, eng->out.ccm.iv, eng->out.ccm.key, eng->out.ccm.seq);
+		setup_aes_ccm_128_crypto_info(&crypto_info_rx, eng->in.ccm.iv, eng->in.ccm.key, eng->in.ccm.seq);
+		break;
+	default:
+		pr_err("cipher %x is not supported with kTLS # command[%s]", params->cipher_suite, current->comm);
+		return -1;
 	}
 
 	// We have to set the protocol to the original here because the kTLS proto gets created from the sockets original protocol,

--- a/socket.c
+++ b/socket.c
@@ -925,12 +925,12 @@ static int configure_ktls_sock(camblet_socket *s)
 			setup_chacha_poly_crypto_info(&crypto_info_rx.chapol, eng->in.chapol.iv, eng->in.chapol.key, eng->in.chapol.seq);
 			break;
 		case BR_TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256:
-			setup_aes_gcm_128_crypto_info(&crypto_info_tx.gcm_128, eng->out.gcm.iv, eng->out.gcm.key.k16, eng->out.gcm.seq);
-			setup_aes_gcm_128_crypto_info(&crypto_info_rx.gcm_128, eng->in.gcm.iv, eng->in.gcm.key.k16, eng->in.gcm.seq);
+			setup_aes_gcm_128_crypto_info(&crypto_info_tx.gcm_128, eng->out.gcm.iv, eng->out.gcm.key, eng->out.gcm.seq);
+			setup_aes_gcm_128_crypto_info(&crypto_info_rx.gcm_128, eng->in.gcm.iv, eng->in.gcm.key, eng->in.gcm.seq);
 			break;
 		case BR_TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384:
-			setup_aes_gcm_256_crypto_info(&crypto_info_tx.gcm_256, eng->out.gcm.iv, eng->out.gcm.key.k32, eng->out.gcm.seq);
-			setup_aes_gcm_256_crypto_info(&crypto_info_rx.gcm_256, eng->in.gcm.iv, eng->in.gcm.key.k32, eng->in.gcm.seq);
+			setup_aes_gcm_256_crypto_info(&crypto_info_tx.gcm_256, eng->out.gcm.iv, eng->out.gcm.key, eng->out.gcm.seq);
+			setup_aes_gcm_256_crypto_info(&crypto_info_rx.gcm_256, eng->in.gcm.iv, eng->in.gcm.key, eng->in.gcm.seq);
 			break;
 		case BR_TLS_RSA_WITH_AES_128_CCM:
 			setup_aes_ccm_128_crypto_info(&crypto_info_tx.ccm_128, eng->out.ccm.iv, eng->out.ccm.key, eng->out.ccm.seq);

--- a/test/smoke.sh
+++ b/test/smoke.sh
@@ -24,8 +24,14 @@ diff bigfile.o bigfile_downloaded.o
 echo "Test bearssl with non-bearssl compatibility"
 python3 -m http.server 7000 >/tmp/python.log &
 sleep 1
-echo "testing with curl..."
+echo "testing with curl using default cipher..."
 curl -k -v https://localhost:7000/
+echo "testing with curl using AES_GCM_128 cipher..."
+curl -k -v --ciphers ECDHE-RSA-AES128-GCM-SHA256 https://localhost:7000/
+echo "testing with curl using AES_GCM_256 cipher..."
+curl -k -v --ciphers ECDHE-RSA-AES256-GCM-SHA384 https://localhost:7000/
+echo "testing with curl using CHACHA_POLY cipher..."
+curl -k -v --ciphers ECDHE-RSA-CHACHA20-POLY1305 https://localhost:7000/
 echo "testing with wget..."
 wget --no-check-certificate https://localhost:7000/
 

--- a/tls.c
+++ b/tls.c
@@ -226,59 +226,59 @@ void br_x509_camblet_free(br_x509_camblet_context *ctx)
 
 void setup_aes_gcm_128_crypto_info(crypto_info *crypto_info, const uint8_t *iv, const uint8_t *key, uint64_t seq)
 {
-    crypto_info->cipher_type.gcm_128.info.version = TLS_1_2_VERSION;
-    crypto_info->cipher_type.gcm_128.info.cipher_type = TLS_CIPHER_AES_GCM_128;
+    crypto_info->cipher.gcm_128.info.version = TLS_1_2_VERSION;
+    crypto_info->cipher.gcm_128.info.cipher_type = TLS_CIPHER_AES_GCM_128;
 
-    memcpy(crypto_info->cipher_type.gcm_128.key, key, TLS_CIPHER_AES_GCM_128_KEY_SIZE);
-    memcpy(crypto_info->cipher_type.gcm_128.salt, iv, TLS_CIPHER_AES_GCM_128_SALT_SIZE);
+    memcpy(crypto_info->cipher.gcm_128.key, key, TLS_CIPHER_AES_GCM_128_KEY_SIZE);
+    memcpy(crypto_info->cipher.gcm_128.salt, iv, TLS_CIPHER_AES_GCM_128_SALT_SIZE);
 
     uint64_t swapseq = m3_bswap64(seq);
-    memcpy(crypto_info->cipher_type.gcm_128.iv, &swapseq, TLS_CIPHER_AES_GCM_128_IV_SIZE);
-    memcpy(crypto_info->cipher_type.gcm_128.rec_seq, &swapseq, TLS_CIPHER_AES_GCM_128_REC_SEQ_SIZE);
+    memcpy(crypto_info->cipher.gcm_128.iv, &swapseq, TLS_CIPHER_AES_GCM_128_IV_SIZE);
+    memcpy(crypto_info->cipher.gcm_128.rec_seq, &swapseq, TLS_CIPHER_AES_GCM_128_REC_SEQ_SIZE);
 
-    crypto_info->cipher_type_len = sizeof(crypto_info->cipher_type.gcm_128);
+    crypto_info->cipher_type_len = sizeof(crypto_info->cipher.gcm_128);
 }
 
 void setup_aes_gcm_256_crypto_info(crypto_info *crypto_info, const uint8_t *iv, const uint8_t *key, uint64_t seq)
 {
-    crypto_info->cipher_type.gcm_256.info.version = TLS_1_2_VERSION;
-    crypto_info->cipher_type.gcm_256.info.cipher_type = TLS_CIPHER_AES_GCM_256;
+    crypto_info->cipher.gcm_256.info.version = TLS_1_2_VERSION;
+    crypto_info->cipher.gcm_256.info.cipher_type = TLS_CIPHER_AES_GCM_256;
 
-    memcpy(crypto_info->cipher_type.gcm_256.key, key, TLS_CIPHER_AES_GCM_256_KEY_SIZE);
-    memcpy(crypto_info->cipher_type.gcm_256.salt, iv, TLS_CIPHER_AES_GCM_256_SALT_SIZE);
+    memcpy(crypto_info->cipher.gcm_256.key, key, TLS_CIPHER_AES_GCM_256_KEY_SIZE);
+    memcpy(crypto_info->cipher.gcm_256.salt, iv, TLS_CIPHER_AES_GCM_256_SALT_SIZE);
 
     uint64_t swapseq = m3_bswap64(seq);
-    memcpy(crypto_info->cipher_type.gcm_256.iv, &swapseq, TLS_CIPHER_AES_GCM_256_IV_SIZE);
-    memcpy(crypto_info->cipher_type.gcm_256.rec_seq, &swapseq, TLS_CIPHER_AES_GCM_256_REC_SEQ_SIZE);
+    memcpy(crypto_info->cipher.gcm_256.iv, &swapseq, TLS_CIPHER_AES_GCM_256_IV_SIZE);
+    memcpy(crypto_info->cipher.gcm_256.rec_seq, &swapseq, TLS_CIPHER_AES_GCM_256_REC_SEQ_SIZE);
 
-    crypto_info->cipher_type_len = sizeof(crypto_info->cipher_type.gcm_256);
+    crypto_info->cipher_type_len = sizeof(crypto_info->cipher.gcm_256);
 }
 
 void setup_chacha_poly_crypto_info(crypto_info *crypto_info, const uint8_t *iv, const uint8_t *key, uint64_t seq)
 {
-    crypto_info->cipher_type.chapol.info.version = TLS_1_2_VERSION;
-    crypto_info->cipher_type.chapol.info.cipher_type = TLS_CIPHER_CHACHA20_POLY1305;
+    crypto_info->cipher.chapol.info.version = TLS_1_2_VERSION;
+    crypto_info->cipher.chapol.info.cipher_type = TLS_CIPHER_CHACHA20_POLY1305;
 
-    memcpy(crypto_info->cipher_type.chapol.iv, iv, TLS_CIPHER_CHACHA20_POLY1305_IV_SIZE);
-    memcpy(crypto_info->cipher_type.chapol.key, key, TLS_CIPHER_CHACHA20_POLY1305_KEY_SIZE);
+    memcpy(crypto_info->cipher.chapol.iv, iv, TLS_CIPHER_CHACHA20_POLY1305_IV_SIZE);
+    memcpy(crypto_info->cipher.chapol.key, key, TLS_CIPHER_CHACHA20_POLY1305_KEY_SIZE);
 
     uint64_t swapseq = m3_bswap64(seq);
-    memcpy(crypto_info->cipher_type.chapol.rec_seq, &swapseq, TLS_CIPHER_CHACHA20_POLY1305_REC_SEQ_SIZE);
-    crypto_info->cipher_type_len = sizeof(crypto_info->cipher_type.chapol);
+    memcpy(crypto_info->cipher.chapol.rec_seq, &swapseq, TLS_CIPHER_CHACHA20_POLY1305_REC_SEQ_SIZE);
+    crypto_info->cipher_type_len = sizeof(crypto_info->cipher.chapol);
 }
 
 void setup_aes_ccm_128_crypto_info(crypto_info *crypto_info, const uint8_t *iv, const uint8_t *key, uint64_t seq)
 {
-    crypto_info->cipher_type.ccm_128.info.version = TLS_1_2_VERSION;
-    crypto_info->cipher_type.ccm_128.info.cipher_type = TLS_CIPHER_AES_CCM_128;
+    crypto_info->cipher.ccm_128.info.version = TLS_1_2_VERSION;
+    crypto_info->cipher.ccm_128.info.cipher_type = TLS_CIPHER_AES_CCM_128;
 
-    memcpy(crypto_info->cipher_type.ccm_128.salt, iv, TLS_CIPHER_AES_CCM_128_SALT_SIZE);
-    memcpy(crypto_info->cipher_type.ccm_128.key, key, TLS_CIPHER_AES_CCM_128_KEY_SIZE);
+    memcpy(crypto_info->cipher.ccm_128.salt, iv, TLS_CIPHER_AES_CCM_128_SALT_SIZE);
+    memcpy(crypto_info->cipher.ccm_128.key, key, TLS_CIPHER_AES_CCM_128_KEY_SIZE);
 
     uint64_t swapseq = m3_bswap64(seq);
-    memcpy(crypto_info->cipher_type.ccm_128.iv, &swapseq, TLS_CIPHER_AES_CCM_128_IV_SIZE);
-    memcpy(crypto_info->cipher_type.ccm_128.rec_seq, &swapseq, TLS_CIPHER_AES_CCM_128_REC_SEQ_SIZE);
-    crypto_info->cipher_type_len = sizeof(crypto_info->cipher_type.ccm_128);
+    memcpy(crypto_info->cipher.ccm_128.iv, &swapseq, TLS_CIPHER_AES_CCM_128_IV_SIZE);
+    memcpy(crypto_info->cipher.ccm_128.rec_seq, &swapseq, TLS_CIPHER_AES_CCM_128_REC_SEQ_SIZE);
+    crypto_info->cipher_type_len = sizeof(crypto_info->cipher.ccm_128);
 }
 
 bool is_cipher_supported(uint16_t cipher_suite)

--- a/tls.c
+++ b/tls.c
@@ -223,3 +223,43 @@ void br_x509_camblet_free(br_x509_camblet_context *ctx)
     }
     kfree(ctx->ctx.name_elts);
 }
+
+void setup_aes_gcm_128_crypto_info(struct tls12_crypto_info_aes_gcm_128 *crypto_info, const uint8_t *iv, const uint8_t *key, uint64_t seq)
+{
+    crypto_info->info.version = TLS_1_2_VERSION;
+    crypto_info->info.cipher_type = TLS_CIPHER_AES_GCM_128;
+	memcpy(crypto_info->iv, iv, TLS_CIPHER_AES_GCM_128_IV_SIZE);
+	memcpy(crypto_info->key, key, TLS_CIPHER_AES_GCM_128_KEY_SIZE);
+	uint64_t outseq = m3_bswap64(seq);
+	memcpy(crypto_info->rec_seq, &outseq, TLS_CIPHER_AES_GCM_128_REC_SEQ_SIZE);
+}
+
+void setup_aes_gcm_256_crypto_info(struct tls12_crypto_info_aes_gcm_256 *crypto_info, const uint8_t *iv, const uint8_t *key, uint64_t seq)
+{
+    crypto_info->info.version = TLS_1_2_VERSION;
+    crypto_info->info.cipher_type = TLS_CIPHER_AES_GCM_256;
+	memcpy(crypto_info->iv, iv, TLS_CIPHER_AES_GCM_256_IV_SIZE);
+	memcpy(crypto_info->key, key, TLS_CIPHER_AES_GCM_256_KEY_SIZE);
+	uint64_t outseq = m3_bswap64(seq);
+	memcpy(crypto_info->rec_seq, &outseq, TLS_CIPHER_AES_GCM_256_REC_SEQ_SIZE);
+}
+
+void setup_chacha_poly_crypto_info(struct tls12_crypto_info_chacha20_poly1305 *crypto_info, const uint8_t *iv, const uint8_t *key, uint64_t seq)
+{
+    crypto_info->info.version = TLS_1_2_VERSION;
+    crypto_info->info.cipher_type = TLS_CIPHER_CHACHA20_POLY1305;
+    memcpy(crypto_info->iv, iv, TLS_CIPHER_CHACHA20_POLY1305_IV_SIZE);
+    memcpy(crypto_info->key, key, TLS_CIPHER_CHACHA20_POLY1305_KEY_SIZE);
+    seq = m3_bswap64(seq);
+    memcpy(crypto_info->rec_seq, &seq, TLS_CIPHER_CHACHA20_POLY1305_REC_SEQ_SIZE);
+}
+
+void setup_aes_ccm_128_crypto_info(struct tls12_crypto_info_aes_ccm_128 *crypto_info, const uint8_t *iv, const uint8_t *key, uint64_t seq)
+{
+    crypto_info->info.version = TLS_1_2_VERSION;
+    crypto_info->info.cipher_type = TLS_CIPHER_AES_CCM_128;
+	memcpy(crypto_info->iv, iv, TLS_CIPHER_AES_CCM_128_IV_SIZE);
+	memcpy(crypto_info->key, key, TLS_CIPHER_AES_CCM_128_KEY_SIZE);
+	uint64_t outseq = m3_bswap64(seq);
+	memcpy(crypto_info->rec_seq, &outseq, TLS_CIPHER_AES_CCM_128_REC_SEQ_SIZE);
+}

--- a/tls.c
+++ b/tls.c
@@ -232,9 +232,9 @@ void setup_aes_gcm_128_crypto_info(crypto_info *crypto_info, const uint8_t *iv, 
     memcpy(crypto_info->cipher_type.gcm_128.key, key, TLS_CIPHER_AES_GCM_128_KEY_SIZE);
     memcpy(crypto_info->cipher_type.gcm_128.salt, iv, TLS_CIPHER_AES_GCM_128_SALT_SIZE);
 
-	uint64_t swapseq = m3_bswap64(seq);
+    uint64_t swapseq = m3_bswap64(seq);
     memcpy(crypto_info->cipher_type.gcm_128.iv, &swapseq, TLS_CIPHER_AES_GCM_128_IV_SIZE);
-	memcpy(crypto_info->cipher_type.gcm_128.rec_seq, &swapseq, TLS_CIPHER_AES_GCM_128_REC_SEQ_SIZE);
+    memcpy(crypto_info->cipher_type.gcm_128.rec_seq, &swapseq, TLS_CIPHER_AES_GCM_128_REC_SEQ_SIZE);
 
     crypto_info->cipher_type_len = sizeof(crypto_info->cipher_type.gcm_128);
 }
@@ -247,9 +247,9 @@ void setup_aes_gcm_256_crypto_info(crypto_info *crypto_info, const uint8_t *iv, 
     memcpy(crypto_info->cipher_type.gcm_256.key, key, TLS_CIPHER_AES_GCM_256_KEY_SIZE);
     memcpy(crypto_info->cipher_type.gcm_256.salt, iv, TLS_CIPHER_AES_GCM_256_SALT_SIZE);
 
-	uint64_t swapseq = m3_bswap64(seq);
+    uint64_t swapseq = m3_bswap64(seq);
     memcpy(crypto_info->cipher_type.gcm_256.iv, &swapseq, TLS_CIPHER_AES_GCM_256_IV_SIZE);
-	memcpy(crypto_info->cipher_type.gcm_256.rec_seq, &swapseq, TLS_CIPHER_AES_GCM_256_REC_SEQ_SIZE);
+    memcpy(crypto_info->cipher_type.gcm_256.rec_seq, &swapseq, TLS_CIPHER_AES_GCM_256_REC_SEQ_SIZE);
 
     crypto_info->cipher_type_len = sizeof(crypto_info->cipher_type.gcm_256);
 }
@@ -273,17 +273,18 @@ void setup_aes_ccm_128_crypto_info(crypto_info *crypto_info, const uint8_t *iv, 
     crypto_info->cipher_type.ccm_128.info.cipher_type = TLS_CIPHER_AES_CCM_128;
 
     memcpy(crypto_info->cipher_type.ccm_128.salt, iv, TLS_CIPHER_AES_CCM_128_SALT_SIZE);
-	memcpy(crypto_info->cipher_type.ccm_128.key, key, TLS_CIPHER_AES_CCM_128_KEY_SIZE);
+    memcpy(crypto_info->cipher_type.ccm_128.key, key, TLS_CIPHER_AES_CCM_128_KEY_SIZE);
 
-	uint64_t swapseq = m3_bswap64(seq);
+    uint64_t swapseq = m3_bswap64(seq);
     memcpy(crypto_info->cipher_type.ccm_128.iv, &swapseq, TLS_CIPHER_AES_CCM_128_IV_SIZE);
-	memcpy(crypto_info->cipher_type.ccm_128.rec_seq, &swapseq, TLS_CIPHER_AES_CCM_128_REC_SEQ_SIZE);
+    memcpy(crypto_info->cipher_type.ccm_128.rec_seq, &swapseq, TLS_CIPHER_AES_CCM_128_REC_SEQ_SIZE);
     crypto_info->cipher_type_len = sizeof(crypto_info->cipher_type.ccm_128);
 }
 
-bool is_cipher_supported(uint16_t cipher_suite) {
+bool is_cipher_supported(uint16_t cipher_suite)
+{
     return cipher_suite == BR_TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256 ||
-		cipher_suite == BR_TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 ||
-		cipher_suite == BR_TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 ||
-		cipher_suite == BR_TLS_RSA_WITH_AES_128_CCM;
+           cipher_suite == BR_TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 ||
+           cipher_suite == BR_TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 ||
+           cipher_suite == BR_TLS_RSA_WITH_AES_128_CCM;
 }

--- a/tls.c
+++ b/tls.c
@@ -224,44 +224,61 @@ void br_x509_camblet_free(br_x509_camblet_context *ctx)
     kfree(ctx->ctx.name_elts);
 }
 
-void setup_aes_gcm_128_crypto_info(struct tls12_crypto_info_aes_gcm_128 *crypto_info, const uint8_t *iv, const uint8_t *key, uint64_t seq)
+void setup_aes_gcm_128_crypto_info(crypto_info *crypto_info, const uint8_t *iv, const uint8_t *key, uint64_t seq)
 {
-    crypto_info->info.version = TLS_1_2_VERSION;
-    crypto_info->info.cipher_type = TLS_CIPHER_AES_GCM_128;
-	memcpy(crypto_info->iv, iv, TLS_CIPHER_AES_GCM_128_IV_SIZE);
-	memcpy(crypto_info->key, key, TLS_CIPHER_AES_GCM_128_KEY_SIZE);
-	uint64_t outseq = m3_bswap64(seq);
-	memcpy(crypto_info->rec_seq, &outseq, TLS_CIPHER_AES_GCM_128_REC_SEQ_SIZE);
+    crypto_info->cipher_type.gcm_128.info.version = TLS_1_2_VERSION;
+    crypto_info->cipher_type.gcm_128.info.cipher_type = TLS_CIPHER_AES_GCM_128;
+
+    memcpy(crypto_info->cipher_type.gcm_128.key, key, TLS_CIPHER_AES_GCM_128_KEY_SIZE);
+    memcpy(crypto_info->cipher_type.gcm_128.salt, iv, TLS_CIPHER_AES_GCM_128_SALT_SIZE);
+
+	uint64_t swapseq = m3_bswap64(seq);
+    memcpy(crypto_info->cipher_type.gcm_128.iv, &swapseq, TLS_CIPHER_AES_GCM_128_IV_SIZE);
+	memcpy(crypto_info->cipher_type.gcm_128.rec_seq, &swapseq, TLS_CIPHER_AES_GCM_128_REC_SEQ_SIZE);
+
+    crypto_info->cipher_type_len = sizeof(crypto_info->cipher_type.gcm_128);
 }
 
-void setup_aes_gcm_256_crypto_info(struct tls12_crypto_info_aes_gcm_256 *crypto_info, const uint8_t *iv, const uint8_t *key, uint64_t seq)
+void setup_aes_gcm_256_crypto_info(crypto_info *crypto_info, const uint8_t *iv, const uint8_t *key, uint64_t seq)
 {
-    crypto_info->info.version = TLS_1_2_VERSION;
-    crypto_info->info.cipher_type = TLS_CIPHER_AES_GCM_256;
-	memcpy(crypto_info->iv, iv, TLS_CIPHER_AES_GCM_256_IV_SIZE);
-	memcpy(crypto_info->key, key, TLS_CIPHER_AES_GCM_256_KEY_SIZE);
-	uint64_t outseq = m3_bswap64(seq);
-	memcpy(crypto_info->rec_seq, &outseq, TLS_CIPHER_AES_GCM_256_REC_SEQ_SIZE);
+    crypto_info->cipher_type.gcm_256.info.version = TLS_1_2_VERSION;
+    crypto_info->cipher_type.gcm_256.info.cipher_type = TLS_CIPHER_AES_GCM_256;
+
+    memcpy(crypto_info->cipher_type.gcm_256.key, key, TLS_CIPHER_AES_GCM_256_KEY_SIZE);
+    memcpy(crypto_info->cipher_type.gcm_256.salt, iv, TLS_CIPHER_AES_GCM_256_SALT_SIZE);
+
+	uint64_t swapseq = m3_bswap64(seq);
+    memcpy(crypto_info->cipher_type.gcm_256.iv, &swapseq, TLS_CIPHER_AES_GCM_256_IV_SIZE);
+	memcpy(crypto_info->cipher_type.gcm_256.rec_seq, &swapseq, TLS_CIPHER_AES_GCM_256_REC_SEQ_SIZE);
+
+    crypto_info->cipher_type_len = sizeof(crypto_info->cipher_type.gcm_256);
 }
 
-void setup_chacha_poly_crypto_info(struct tls12_crypto_info_chacha20_poly1305 *crypto_info, const uint8_t *iv, const uint8_t *key, uint64_t seq)
+void setup_chacha_poly_crypto_info(crypto_info *crypto_info, const uint8_t *iv, const uint8_t *key, uint64_t seq)
 {
-    crypto_info->info.version = TLS_1_2_VERSION;
-    crypto_info->info.cipher_type = TLS_CIPHER_CHACHA20_POLY1305;
-    memcpy(crypto_info->iv, iv, TLS_CIPHER_CHACHA20_POLY1305_IV_SIZE);
-    memcpy(crypto_info->key, key, TLS_CIPHER_CHACHA20_POLY1305_KEY_SIZE);
-    seq = m3_bswap64(seq);
-    memcpy(crypto_info->rec_seq, &seq, TLS_CIPHER_CHACHA20_POLY1305_REC_SEQ_SIZE);
+    crypto_info->cipher_type.chapol.info.version = TLS_1_2_VERSION;
+    crypto_info->cipher_type.chapol.info.cipher_type = TLS_CIPHER_CHACHA20_POLY1305;
+
+    memcpy(crypto_info->cipher_type.chapol.iv, iv, TLS_CIPHER_CHACHA20_POLY1305_IV_SIZE);
+    memcpy(crypto_info->cipher_type.chapol.key, key, TLS_CIPHER_CHACHA20_POLY1305_KEY_SIZE);
+
+    uint64_t swapseq = m3_bswap64(seq);
+    memcpy(crypto_info->cipher_type.chapol.rec_seq, &swapseq, TLS_CIPHER_CHACHA20_POLY1305_REC_SEQ_SIZE);
+    crypto_info->cipher_type_len = sizeof(crypto_info->cipher_type.chapol);
 }
 
-void setup_aes_ccm_128_crypto_info(struct tls12_crypto_info_aes_ccm_128 *crypto_info, const uint8_t *iv, const uint8_t *key, uint64_t seq)
+void setup_aes_ccm_128_crypto_info(crypto_info *crypto_info, const uint8_t *iv, const uint8_t *key, uint64_t seq)
 {
-    crypto_info->info.version = TLS_1_2_VERSION;
-    crypto_info->info.cipher_type = TLS_CIPHER_AES_CCM_128;
-	memcpy(crypto_info->iv, iv, TLS_CIPHER_AES_CCM_128_IV_SIZE);
-	memcpy(crypto_info->key, key, TLS_CIPHER_AES_CCM_128_KEY_SIZE);
-	uint64_t outseq = m3_bswap64(seq);
-	memcpy(crypto_info->rec_seq, &outseq, TLS_CIPHER_AES_CCM_128_REC_SEQ_SIZE);
+    crypto_info->cipher_type.ccm_128.info.version = TLS_1_2_VERSION;
+    crypto_info->cipher_type.ccm_128.info.cipher_type = TLS_CIPHER_AES_CCM_128;
+
+    memcpy(crypto_info->cipher_type.ccm_128.salt, iv, TLS_CIPHER_AES_CCM_128_SALT_SIZE);
+	memcpy(crypto_info->cipher_type.ccm_128.key, key, TLS_CIPHER_AES_CCM_128_KEY_SIZE);
+
+	uint64_t swapseq = m3_bswap64(seq);
+    memcpy(crypto_info->cipher_type.ccm_128.iv, &swapseq, TLS_CIPHER_AES_CCM_128_IV_SIZE);
+	memcpy(crypto_info->cipher_type.ccm_128.rec_seq, &swapseq, TLS_CIPHER_AES_CCM_128_REC_SEQ_SIZE);
+    crypto_info->cipher_type_len = sizeof(crypto_info->cipher_type.ccm_128);
 }
 
 bool is_cipher_supported(uint16_t cipher_suite) {

--- a/tls.c
+++ b/tls.c
@@ -263,3 +263,10 @@ void setup_aes_ccm_128_crypto_info(struct tls12_crypto_info_aes_ccm_128 *crypto_
 	uint64_t outseq = m3_bswap64(seq);
 	memcpy(crypto_info->rec_seq, &outseq, TLS_CIPHER_AES_CCM_128_REC_SEQ_SIZE);
 }
+
+bool is_cipher_supported(uint16_t cipher_suite) {
+    return cipher_suite == BR_TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256 ||
+		cipher_suite == BR_TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 ||
+		cipher_suite == BR_TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 ||
+		cipher_suite == BR_TLS_RSA_WITH_AES_128_CCM;
+}

--- a/tls.h
+++ b/tls.h
@@ -34,7 +34,8 @@ typedef struct br_x509_camblet_context
 
 typedef struct crypto_info
 {
-    union {
+    union
+    {
         struct tls12_crypto_info_aes_ccm_128 ccm_128;
         struct tls12_crypto_info_aes_gcm_128 gcm_128;
         struct tls12_crypto_info_aes_gcm_256 gcm_256;

--- a/tls.h
+++ b/tls.h
@@ -32,14 +32,25 @@ typedef struct br_x509_camblet_context
     bool insecure;
 } br_x509_camblet_context;
 
+typedef struct crypto_info
+{
+    union {
+        struct tls12_crypto_info_aes_ccm_128 ccm_128;
+        struct tls12_crypto_info_aes_gcm_128 gcm_128;
+        struct tls12_crypto_info_aes_gcm_256 gcm_256;
+        struct tls12_crypto_info_chacha20_poly1305 chapol;
+    } cipher_type;
+    size_t cipher_type_len;
+} crypto_info;
+
 void br_x509_camblet_init(br_x509_camblet_context *ctx, br_ssl_engine_context *eng, opa_socket_context *socket_context, tcp_connection_context *conn_ctx, bool insecure);
 void br_x509_camblet_free(br_x509_camblet_context *ctx);
 
 bool is_tls_handshake(const uint8_t *b);
 
-void setup_aes_ccm_128_crypto_info(struct tls12_crypto_info_aes_ccm_128 *crypto_info, const uint8_t *iv, const uint8_t *key, uint64_t seq);
-void setup_aes_gcm_128_crypto_info(struct tls12_crypto_info_aes_gcm_128 *crypto_info, const uint8_t *iv, const uint8_t *key, uint64_t seq);
-void setup_aes_gcm_256_crypto_info(struct tls12_crypto_info_aes_gcm_256 *crypto_info, const uint8_t *iv, const uint8_t *key, uint64_t seq);
-void setup_chacha_poly_crypto_info(struct tls12_crypto_info_chacha20_poly1305 *crypto_info, const uint8_t *iv, const uint8_t *key, uint64_t seq);
+void setup_aes_ccm_128_crypto_info(crypto_info *crypto_info, const uint8_t *iv, const uint8_t *key, uint64_t seq);
+void setup_aes_gcm_128_crypto_info(crypto_info *crypto_info, const uint8_t *iv, const uint8_t *key, uint64_t seq);
+void setup_aes_gcm_256_crypto_info(crypto_info *crypto_info, const uint8_t *iv, const uint8_t *key, uint64_t seq);
+void setup_chacha_poly_crypto_info(crypto_info *crypto_info, const uint8_t *iv, const uint8_t *key, uint64_t seq);
 bool is_cipher_supported(uint16_t cipher_suite);
 #endif

--- a/tls.h
+++ b/tls.h
@@ -41,4 +41,5 @@ void setup_aes_ccm_128_crypto_info(struct tls12_crypto_info_aes_ccm_128 *crypto_
 void setup_aes_gcm_128_crypto_info(struct tls12_crypto_info_aes_gcm_128 *crypto_info, const uint8_t *iv, const uint8_t *key, uint64_t seq);
 void setup_aes_gcm_256_crypto_info(struct tls12_crypto_info_aes_gcm_256 *crypto_info, const uint8_t *iv, const uint8_t *key, uint64_t seq);
 void setup_chacha_poly_crypto_info(struct tls12_crypto_info_chacha20_poly1305 *crypto_info, const uint8_t *iv, const uint8_t *key, uint64_t seq);
+bool is_cipher_supported(uint16_t cipher_suite);
 #endif

--- a/tls.h
+++ b/tls.h
@@ -40,7 +40,7 @@ typedef struct crypto_info
         struct tls12_crypto_info_aes_gcm_128 gcm_128;
         struct tls12_crypto_info_aes_gcm_256 gcm_256;
         struct tls12_crypto_info_chacha20_poly1305 chapol;
-    } cipher_type;
+    } cipher;
     size_t cipher_type_len;
 } crypto_info;
 

--- a/tls.h
+++ b/tls.h
@@ -14,6 +14,7 @@
 #include "bearssl.h"
 #include "opa.h"
 #include "socket.h"
+#include <net/tls.h>
 
 /*
  * This is a wrapper around the BearSSL X.509 validation engine. It
@@ -36,4 +37,8 @@ void br_x509_camblet_free(br_x509_camblet_context *ctx);
 
 bool is_tls_handshake(const uint8_t *b);
 
+void setup_aes_ccm_128_crypto_info(struct tls12_crypto_info_aes_ccm_128 *crypto_info, const uint8_t *iv, const uint8_t *key, uint64_t seq);
+void setup_aes_gcm_128_crypto_info(struct tls12_crypto_info_aes_gcm_128 *crypto_info, const uint8_t *iv, const uint8_t *key, uint64_t seq);
+void setup_aes_gcm_256_crypto_info(struct tls12_crypto_info_aes_gcm_256 *crypto_info, const uint8_t *iv, const uint8_t *key, uint64_t seq);
+void setup_chacha_poly_crypto_info(struct tls12_crypto_info_chacha20_poly1305 *crypto_info, const uint8_t *iv, const uint8_t *key, uint64_t seq);
 #endif


### PR DESCRIPTION
## Description

Add support for aes GCM and CCM based ciphers when using kTLS.

## Type of Change

- [ ] Bug Fix
- [X] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)
