### PR TITLE
socket: propagate non-block error codes upwards

### DIFF
--- a/socket.c
+++ b/socket.c
@@ -698,7 +698,11 @@ int camblet_recvmsg(struct sock *sock,
 
 			if (ret == -EAGAIN || ret == -EWOULDBLOCK)
 			{
-				continue;
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 19, 0)
+				int nonblock = flags & MSG_DONTWAIT;
+#endif
+				if (nonblock == 0)
+					continue;
 			}
 
 			goto bail;


### PR DESCRIPTION
## Description

We forced a busy loop for non-blocking applications (CPU 100%) instead of propagating the error code that they are prepared to handle, since they requested `MSG_DONTWAIT`. This PR fixes this.

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
