### PR TITLE
socket: fix for bearrssl pre-read data vs poll()

### DIFF
--- a/test/smoke.sh
+++ b/test/smoke.sh
@@ -13,7 +13,10 @@ sudo docker run -d --rm -p 8080:80 nginx
 
 sleep 2
 
-echo "Test downloading a bigger file"
+echo "Test a normal directory listing with wget"
+wget -d http://localhost:8000/ -O /dev/null
+
+echo "Test downloading a bigger file with curl"
 head -c 2M </dev/urandom > bigfile.o
 curl -v -o /tmp/bigfile_downloaded.o http://localhost:8000/bigfile.o
 


### PR DESCRIPTION
## Description

Fixes: #179 

BearSSL reads full TLS records, but the upper application doesn't know that, and if it waits for new data to be read for example with a select(), it will never get notified since the data is already in the BearSSL buffer. This fix overcomes this situation.

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] Implement inet_ipv6 support for this
- [ ] add test case with wget