### PR TITLE
Add read/write buffer lock during send/recvmsg

### DIFF
--- a/socket.c
+++ b/socket.c
@@ -158,9 +158,17 @@ static int ktls_recvmsg(camblet_socket *s, void *buf, size_t size, int flags)
 
 	iov_iter_kvec(&hdr.msg_iter, READ, &iov, 1, buf_len);
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 19, 0)
+	int nonblock = 0;
+	if (flags & MSG_DONTWAIT)
+	{
+		nonblock = MSG_DONTWAIT;
+	}
+#endif
+
 	return s->ktls_recvmsg(s->sock, &hdr, size,
 #if LINUX_VERSION_CODE < KERNEL_VERSION(5, 19, 0)
-						   0,
+						   nonblock,
 #endif
 						   flags, &addr_len);
 }

--- a/socket.c
+++ b/socket.c
@@ -2002,12 +2002,12 @@ __poll_t camblet_poll(struct file *file, struct socket *sock,
 		{
 			size_t left;
 
-			mutex_lock(&s->lock);
+			mutex_lock(&s->bearssl_lock);
 			{
 				br_ssl_engine_context *ctx = get_ssl_engine_context(s);
 				br_ssl_engine_recvapp_buf(ctx, &left);
 			}
-			mutex_unlock(&s->lock);
+			mutex_unlock(&s->bearssl_lock);
 
 			if (left > 0)
 			{

--- a/socket.c
+++ b/socket.c
@@ -101,7 +101,7 @@ struct camblet_socket
 	i64 direction;
 	char *alpn;
 
-	//BearSSL is not thread safe so we need to lock every interaction with it
+	// BearSSL is not thread safe so we need to lock every interaction with it
 	struct mutex bearssl_lock;
 
 	struct mutex readbuffer_lock;
@@ -523,6 +523,9 @@ static camblet_socket *camblet_new_client_socket(struct sock *sock, opa_socket_c
 	s->direction = OUTPUT;
 
 	mutex_init(&s->bearssl_lock);
+
+	mutex_init(&s->readbuffer_lock);
+	mutex_init(&s->writebuffer_lock);
 
 	proxywasm *p = this_cpu_proxywasm();
 


### PR DESCRIPTION
## Description

This pull request introduces read and write buffer locks to the camblet_sendmsg and camblet_recvmsg functions. Additionally, it addresses discrepancies in kernel versions about the MSG_DONTWAIT flag for kTLS.

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

