### PR TITLE
socket: fixes around camblet_get/setsockopt and recvmsg waiting and other things

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Makefile CI
+name: Build and test
 
 on:
   push:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,7 +79,7 @@ jobs:
     #     ## limits ssh access and adds the ssh public key for the user which triggered the workflow
     #     limit-access-to-actor: true
 
-    - name: Run proxy-wasm smoke test with kTLS
+    - name: Run smoke test with kTLS
       uses: ./camblet-driver/.github/actions/smoketest
       timeout-minutes: 1
  
@@ -94,6 +94,6 @@ jobs:
         sudo modprobe camblet dyndbg==_ ktls_available=0
         sudo dmesg -T
 
-    - name: Run proxy-wasm smoke test with bearSSL
+    - name: Run smoke test with bearSSL
       uses: ./camblet-driver/.github/actions/smoketest
       timeout-minutes: 1

--- a/include/camblet.h
+++ b/include/camblet.h
@@ -25,6 +25,6 @@ typedef struct
     bool mtls_enabled;
     char spiffe_id[256];
     char peer_spiffe_id[256];
-} tls_info;
+} camblet_tls_info;
 
 #endif /* camblet_h */

--- a/include/camblet.h
+++ b/include/camblet.h
@@ -11,9 +11,11 @@
 #ifndef camblet_h
 #define camblet_h
 
+
 #define SOL_CAMBLET 7891
 #define CAMBLET_HOSTNAME 1
 #define CAMBLET_TLS_INFO 2
+#define CAMBLET "camblet"
 
 #define CAMBLET_EINVALIDSPIFFEID 1001
 

--- a/src/commands.c
+++ b/src/commands.c
@@ -26,7 +26,6 @@ static LIST_HEAD(command_list);
 
 // lock for the above list to make it thread safe
 static DEFINE_MUTEX(command_list_lock);
-static unsigned long command_list_lock_flags;
 
 // wait queue for the driver to be woken up when a command is added to the list
 static DECLARE_WAIT_QUEUE_HEAD(command_wait_queue);

--- a/src/socket.c
+++ b/src/socket.c
@@ -1304,6 +1304,8 @@ static opa_socket_context socket_eval(const tcp_connection_context *conn_ctx, co
 	return ctx;
 }
 
+// Save original prot methods to be able to use and restore them later.
+
 struct sock *(*accept)(struct sock *sk, int flags, int *err, bool kern);
 int (*connect)(struct sock *sk, struct sockaddr *uaddr, int addr_len);
 int (*setsockopt)(struct sock *sk, int level,
@@ -2172,16 +2174,15 @@ int socket_init(void)
 	tcp_prot.accept = camblet_accept;
 	tcp_prot.connect = camblet_connect;
 	tcp_prot.setsockopt = camblet_setsockopt;
-	tcp_prot.getsockopt = camblet_getsockopt;
 
 	tcpv6_prot.accept = camblet_accept;
 	tcpv6_prot.connect = camblet_connect;
 	tcpv6_prot.setsockopt = camblet_setsockopt;
-	tcpv6_prot.getsockopt = camblet_getsockopt;
 
 	memcpy(&camblet_prot, &tcp_prot, sizeof(camblet_prot));
 	camblet_prot.recvmsg = camblet_recvmsg;
 	camblet_prot.sendmsg = camblet_sendmsg;
+	camblet_prot.getsockopt = camblet_getsockopt;
 	camblet_prot.close = camblet_close;
 
 	memcpy(&camblet_ktls_prot, &camblet_prot, sizeof(camblet_prot));
@@ -2190,6 +2191,7 @@ int socket_init(void)
 	memcpy(&camblet_v6_prot, &tcpv6_prot, sizeof(camblet_v6_prot));
 	camblet_v6_prot.recvmsg = camblet_recvmsg;
 	camblet_v6_prot.sendmsg = camblet_sendmsg;
+	camblet_v6_prot.getsockopt = camblet_getsockopt;
 	camblet_v6_prot.close = camblet_close;
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(6, 5, 0)

--- a/src/socket.c
+++ b/src/socket.c
@@ -1305,7 +1305,7 @@ int camblet_getsockopt(struct sock *sk, int level,
 			return err;
 		}
 
-		tls_info info = {};
+		camblet_tls_info info = {0};
 
 		info.camblet_enabled = s->opa_socket_ctx.allowed;
 		info.mtls_enabled = s->opa_socket_ctx.mtls;

--- a/test/file-server.go
+++ b/test/file-server.go
@@ -66,6 +66,14 @@ func certificate() tls.Certificate {
 var port int
 var tlsOn bool
 
+// logger middleware
+func logger(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		log.Printf("%s %s %s", r.RemoteAddr, r.Method, r.URL)
+		next.ServeHTTP(w, r)
+	})
+}
+
 func main() {
 
 	flag.IntVar(&port, "port", 8000, "Listening port")
@@ -115,7 +123,7 @@ func main() {
 		}
 	})
 
-	http.Handle("/", http.FileServer(http.Dir("./")))
+	http.Handle("/", logger(http.FileServer(http.Dir("./"))))
 
 	var err error
 
@@ -124,7 +132,7 @@ func main() {
 
 		tlsConfig := &tls.Config{
 			Certificates: []tls.Certificate{certificate()},
-			NextProtos:   []string{"h2", "http/1.1", "camblet"},
+			NextProtos:   []string{"h2", "http/1.1"},
 		}
 
 		l, err := net.Listen("tcp", fmt.Sprintf(":%d", port))

--- a/test/file-server.go
+++ b/test/file-server.go
@@ -39,6 +39,7 @@ func certificate() tls.Certificate {
 		Subject: pkix.Name{
 			Organization: []string{"Cis Co"},
 		},
+		DNSNames:  []string{"localhost"},
 		NotBefore: time.Now(),
 		NotAfter:  time.Now().Add(time.Hour * 24 * 180),
 

--- a/test/file-server.go
+++ b/test/file-server.go
@@ -124,7 +124,7 @@ func main() {
 
 		tlsConfig := &tls.Config{
 			Certificates: []tls.Certificate{certificate()},
-			NextProtos:   []string{"h2", "http/1.1"},
+			NextProtos:   []string{"h2", "http/1.1", "camblet"},
 		}
 
 		l, err := net.Listen("tcp", fmt.Sprintf(":%d", port))

--- a/test/file-server.go
+++ b/test/file-server.go
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2023 Cisco and/or its affiliates. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT OR GPL-2.0-only
+ *
+ * Licensed under the MIT license <LICENSE.MIT or https://opensource.org/licenses/MIT> or the GPLv2 license
+ * <LICENSE.GPL or https://opensource.org/license/gpl-2-0>, at your option. This file may not be copied,
+ * modified, or distributed except according to those terms.
+ */
+
 package main
 
 import (

--- a/test/smoke.sh
+++ b/test/smoke.sh
@@ -8,6 +8,9 @@ go build test/file-server.go
 echo "Starting file server"
 ./file-server >/tmp/file-server.log 2>&1 &
 
+echo "Starting file server with TLS"
+./file-server -tls -port 8007 >/tmp/file-server-tls.log 2>&1 &
+
 echo "Starting NGiNX in docker"
 sudo docker run -d --rm -p 8080:80 nginx
 
@@ -56,6 +59,10 @@ for i in `seq 1 100`; do curl -s -o/dev/null localhost:8080; echo $?; done |sort
 echo "Test sendfile with NGiNX using wget"
 echo -e "    100 0" > test.output
 for i in `seq 1 100`; do wget -q -O/dev/null localhost:8080; echo $?; done |sort|uniq -c|diff - test.output
+
+echo "Test sockopt on file-server with TLS"
+gcc -o sockopt test/sockopt.c
+./sockopt
 
 echo "Stop processes"
 sudo pkill python3

--- a/test/sockopt.c
+++ b/test/sockopt.c
@@ -8,7 +8,7 @@
  * modified, or distributed except according to those terms.
  */
 
-// this is a simple test program that connets to a server and sets and gets a few socket options,
+// this is a simple test program that connects to a server and sets and gets a few socket options,
 // then connects to a server and sends a http message
 
 #include <stdio.h>

--- a/test/sockopt.c
+++ b/test/sockopt.c
@@ -37,11 +37,12 @@ int main(int argc, char **argv)
         return 1;
     }
 
-    // if (setsockopt(sock, SOL_TCP, TCP_ULP, CAMBLET_HOSTNAME, sizeof(CAMBLET)) < 0)
-    // {
-    //     perror("setsockopt");
-    //     return 1;
-    // }
+    char hostname[] = "localhost";
+    if (setsockopt(sock, SOL_CAMBLET, CAMBLET_HOSTNAME, hostname, sizeof(hostname)) < 0)
+    {
+        perror("setsockopt");
+        return 1;
+    }
 
     socklen_t optlen;
     if (getsockopt(sock, SOL_SOCKET, SO_SNDBUF, &optval, &optlen) < 0)
@@ -74,19 +75,17 @@ int main(int argc, char **argv)
     }
 
     printf("Sent:\n%s\n", msg);
-    printf("Received:\n");
 
-    char buf[1024];
+    char buf[8096];
     int n;
-    while ((n = recv(sock, buf, sizeof(buf), 0)) > 0)
-    {
-        printf("%.*s", n, buf);
-    }
-    if (n < 0)
+    if ((n = recv(sock, buf, sizeof(buf), 0)) < 0)
     {
         perror("recv");
         return 1;
     }
+
+    printf("Received [%d bytes] at first:\n", n);
+    printf("%.*s\n", n, buf);
 
     close(sock);
 

--- a/test/sockopt.c
+++ b/test/sockopt.c
@@ -20,21 +20,32 @@
 
 #include "../include/camblet.h"
 
-int main(int argc, char **argv) {
+int main(int argc, char **argv)
+{
     int sock = socket(AF_INET, SOCK_STREAM, 0);
-    if (sock < 0) {
+    if (sock < 0)
+    {
         perror("socket");
         return 1;
     }
 
+    // setting sockopt "SOL_TCP, TCP_ULP, CAMBLET" should be set before connect
     int optval = 1;
-    if (setsockopt(sock, SOL_TCP, TCP_ULP, CAMBLET, sizeof(CAMBLET)) < 0) {
+    if (setsockopt(sock, SOL_TCP, TCP_ULP, CAMBLET, sizeof(CAMBLET)) < 0)
+    {
         perror("setsockopt");
         return 1;
     }
 
+    // if (setsockopt(sock, SOL_TCP, TCP_ULP, CAMBLET_HOSTNAME, sizeof(CAMBLET)) < 0)
+    // {
+    //     perror("setsockopt");
+    //     return 1;
+    // }
+
     socklen_t optlen;
-    if (getsockopt(sock, SOL_SOCKET, SO_SNDBUF, &optval, &optlen) < 0) {
+    if (getsockopt(sock, SOL_SOCKET, SO_SNDBUF, &optval, &optlen) < 0)
+    {
         perror("getsockopt");
         return 1;
     }
@@ -46,7 +57,8 @@ int main(int argc, char **argv) {
     addr.sin_port = htons(8000);
     addr.sin_addr.s_addr = inet_addr("127.0.0.1");
 
-    if (connect(sock, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
+    if (connect(sock, (struct sockaddr *)&addr, sizeof(addr)) < 0)
+    {
         perror("connect");
         return 1;
     }
@@ -55,23 +67,26 @@ int main(int argc, char **argv) {
 
     // send a simple http request
     const char *msg = "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n";
-    if (send(sock, msg, strlen(msg), 0) < 0) {
+    if (send(sock, msg, strlen(msg), 0) < 0)
+    {
         perror("send");
         return 1;
     }
 
     printf("Sent:\n%s\n", msg);
+    printf("Received:\n");
 
     char buf[1024];
-    int n = recv(sock, buf, sizeof(buf), 0);
-    if (n < 0) {
+    int n;
+    while ((n = recv(sock, buf, sizeof(buf), 0)) > 0)
+    {
+        printf("%.*s", n, buf);
+    }
+    if (n < 0)
+    {
         perror("recv");
         return 1;
     }
-
-    buf[n] = '\0';
-
-    printf("Received:\n%s\n...\n", buf);
 
     close(sock);
 

--- a/test/sockopt.c
+++ b/test/sockopt.c
@@ -55,7 +55,7 @@ int main(int argc, char **argv)
     }
 
     // Camblet socket options can be read after connect
-    tls_info tls_info;
+    camblet_tls_info tls_info;
     socklen_t tls_inf_len = sizeof(tls_info);
     if (getsockopt(sock, SOL_CAMBLET, CAMBLET_TLS_INFO, &tls_info, &tls_inf_len) < 0)
     {

--- a/test/sockopt.c
+++ b/test/sockopt.c
@@ -55,7 +55,7 @@ int main(int argc, char **argv)
 
     struct sockaddr_in addr;
     addr.sin_family = AF_INET;
-    addr.sin_port = htons(8000);
+    addr.sin_port = htons(8007);
     addr.sin_addr.s_addr = inet_addr("127.0.0.1");
 
     if (connect(sock, (struct sockaddr *)&addr, sizeof(addr)) < 0)

--- a/test/sockopt.c
+++ b/test/sockopt.c
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2024 Cisco and/or its affiliates. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT OR GPL-2.0-only
+ *
+ * Licensed under the MIT license <LICENSE.MIT or https://opensource.org/licenses/MIT> or the GPLv2 license
+ * <LICENSE.GPL or https://opensource.org/license/gpl-2-0>, at your option. This file may not be copied,
+ * modified, or distributed except according to those terms.
+ */
+
+// this is a simple test program that connets to a server and sets and gets a few socket options,
+// then connects to a server and sends a http message
+
+#include <stdio.h>
+#include <stdbool.h>
+#include <string.h>
+#include <arpa/inet.h>
+#include <netinet/tcp.h>
+#include <unistd.h>
+
+#include "../include/camblet.h"
+
+int main(int argc, char **argv) {
+    int sock = socket(AF_INET, SOCK_STREAM, 0);
+    if (sock < 0) {
+        perror("socket");
+        return 1;
+    }
+
+    int optval = 1;
+    if (setsockopt(sock, SOL_TCP, TCP_ULP, CAMBLET, sizeof(CAMBLET)) < 0) {
+        perror("setsockopt");
+        return 1;
+    }
+
+    socklen_t optlen;
+    if (getsockopt(sock, SOL_SOCKET, SO_SNDBUF, &optval, &optlen) < 0) {
+        perror("getsockopt");
+        return 1;
+    }
+
+    printf("SO_SNDBUF: %d\n", optval);
+
+    struct sockaddr_in addr;
+    addr.sin_family = AF_INET;
+    addr.sin_port = htons(8000);
+    addr.sin_addr.s_addr = inet_addr("127.0.0.1");
+
+    if (connect(sock, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
+        perror("connect");
+        return 1;
+    }
+
+    // send a simple http request
+    const char *msg = "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n";
+    if (send(sock, msg, strlen(msg), 0) < 0) {
+        perror("send");
+        return 1;
+    }
+
+    char buf[1024];
+    int n = recv(sock, buf, sizeof(buf), 0);
+    if (n < 0) {
+        perror("recv");
+        return 1;
+    }
+
+    buf[n] = '\0';
+
+    printf("Received: %s\n", buf);
+
+    close(sock);
+
+    return 0;
+}

--- a/test/sockopt.c
+++ b/test/sockopt.c
@@ -51,12 +51,16 @@ int main(int argc, char **argv) {
         return 1;
     }
 
+    printf("Connected to server\n");
+
     // send a simple http request
     const char *msg = "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n";
     if (send(sock, msg, strlen(msg), 0) < 0) {
         perror("send");
         return 1;
     }
+
+    printf("Sent:\n%s\n", msg);
 
     char buf[1024];
     int n = recv(sock, buf, sizeof(buf), 0);
@@ -67,7 +71,7 @@ int main(int argc, char **argv) {
 
     buf[n] = '\0';
 
-    printf("Received: %s\n", buf);
+    printf("Received:\n%s\n...\n", buf);
 
     close(sock);
 


### PR DESCRIPTION
## Description

Original getsockopt restoration in module exit was missing (interesting situations could occur after module unload...), but from now on it is not needed since the overwrite is socket local.

Fixing tcp_connection_context memory placing issue in camblet_setsockopt.

Fix for CPU hog read waits.

Added test for Camblet sockopt functions.

Check the commits for all the fixes.

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [x] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
