### PR TITLE
socket: fix leaking tcp_connection_contexts and opa objects

### DIFF
--- a/src/socket.c
+++ b/src/socket.c
@@ -2051,6 +2051,7 @@ struct sock *camblet_accept(struct sock *sk, int flags, int *err, bool kern)
 	}
 	else
 	{
+		opa_socket_context_free(opa_socket_ctx);
 		tcp_connection_context_free(conn_ctx);
 	}
 
@@ -2200,6 +2201,7 @@ int camblet_connect(struct sock *sk, struct sockaddr *uaddr, int addr_len)
 	}
 	else
 	{
+		opa_socket_context_free(opa_socket_ctx);
 		tcp_connection_context_free(conn_ctx);
 	}
 

--- a/src/socket.c
+++ b/src/socket.c
@@ -2000,9 +2000,7 @@ struct sock *camblet_accept(struct sock *sk, int flags, int *err, bool kern)
 	opa_socket_context opa_socket_ctx = enriched_socket_eval(conn_ctx, INPUT, client_sk, port);
 	if (opa_socket_ctx.error < 0)
 	{
-		tcp_connection_context_free(conn_ctx);
 		*err = opa_socket_ctx.error;
-		opa_socket_context_free(opa_socket_ctx);
 		goto error;
 	}
 
@@ -2059,6 +2057,8 @@ struct sock *camblet_accept(struct sock *sk, int flags, int *err, bool kern)
 
 error:
 	camblet_socket_free(sc);
+	opa_socket_context_free(opa_socket_ctx);
+	tcp_connection_context_free(conn_ctx);
 	if (client_sk)
 		client_sk->sk_prot->close(client_sk, 0);
 
@@ -2143,9 +2143,7 @@ int camblet_connect(struct sock *sk, struct sockaddr *uaddr, int addr_len)
 	opa_socket_context opa_socket_ctx = enriched_socket_eval(conn_ctx, OUTPUT, sk, port);
 	if (opa_socket_ctx.error < 0)
 	{
-		tcp_connection_context_free(conn_ctx);
 		err = opa_socket_ctx.error;
-		opa_socket_context_free(opa_socket_ctx);
 		goto error;
 	}
 
@@ -2209,6 +2207,8 @@ int camblet_connect(struct sock *sk, struct sockaddr *uaddr, int addr_len)
 
 error:
 	camblet_socket_free(sc);
+	opa_socket_context_free(opa_socket_ctx);
+	tcp_connection_context_free(conn_ctx);
 	socket_reset(sk);
 
 	return err;

--- a/src/socket.c
+++ b/src/socket.c
@@ -2049,6 +2049,10 @@ struct sock *camblet_accept(struct sock *sk, int flags, int *err, bool kern)
 		client_sk->sk_user_data = sc;
 		WRITE_ONCE(client_sk->sk_prot, prot);
 	}
+	else
+	{
+		tcp_connection_context_free(conn_ctx);
+	}
 
 	return client_sk;
 
@@ -2193,6 +2197,10 @@ int camblet_connect(struct sock *sk, struct sockaddr *uaddr, int addr_len)
 		sk->sk_user_data = sc;
 		WRITE_ONCE(sk->sk_prot, prot);
 		WRITE_ONCE(sk->sk_socket->ops, prot_ops);
+	}
+	else
+	{
+		tcp_connection_context_free(conn_ctx);
 	}
 
 	return err;


### PR DESCRIPTION
## Description

The title is self-explanatory.

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
