### PR TITLE
Add Debian package test to release process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,9 @@ jobs:
       - name: Build camblet-driver Debian package
         run: make deb
 
+      - name: Test camblet-driver Debian package
+        run: sudo apt install -y ../camblet-driver_${{github.ref_name}}_all.deb
+
       - name: Build camblet-driver RedHat package
         run: make rpm
 


### PR DESCRIPTION
## Description

This PR adds an install step to the release phase. It helps to fail fast in case of a package error.

## Type of Change

- [X] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

