### PR TITLE
memory corruption and RCU fixes (for bugs discovered on a debug kernel)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,6 +92,9 @@ default: bearssl
 bearssl:
 	cd third-party/BearSSL && $(MAKE) VERBOSE=$(VERBOSE) linux-km
 
+bearssl_clean:
+	cd third-party/BearSSL && $(MAKE) VERBOSE=$(VERBOSE) linux-km-clean
+
 static/socket_wasm.h: socket.rego
 	opa build -t wasm -e "socket/allow" socket.rego -o bundle.tar.gz
 	tar zxf bundle.tar.gz /policy.wasm
@@ -106,7 +109,7 @@ static/csr_wasm.h: wasm-modules/csr-rust/**/*.rs
 opa-test:
 	opa test *.rego -v
 
-clean:
+clean: bearssl_clean
 	$(MAKE) -C $(KBUILD) M=$(PWD) clean
 	rm -rf target/
 

--- a/include/wasm.h
+++ b/include/wasm.h
@@ -84,6 +84,7 @@ void wasm_vm_unlock(wasm_vm *vm);
 wasm_vm_result wasm_vm_get_module(wasm_vm *vm, const char *module);
 wasm_vm_result wasm_vm_get_function(wasm_vm *vm, const char *module, const char *function);
 const char *wasm_vm_last_error(wasm_vm_module *module);
+wasm_vm_result wasm_vm_compile_module(wasm_vm_module *module);
 
 M3Result SuppressLookupFailure(M3Result i_result);
 

--- a/src/augmentation.c
+++ b/src/augmentation.c
@@ -196,7 +196,10 @@ augmentation_response *augment_workload()
 
     char *key = get_task_context_key(ctx);
     if (IS_ERR(key))
+    {
+        free_task_context(ctx);
         return (void *)key;
+    }
 
     augmentation_response_cache_lock();
     response = augmentation_response_cache_get_locked(key);
@@ -255,10 +258,12 @@ augmentation_response *augment_workload()
     free_command_answer(answer);
 
 ret:
+    free_task_context(ctx);
     kfree(key);
     return response;
 
 error:
+    free_task_context(ctx);
     kfree(key);
     augmentation_response_free(response);
     return error;

--- a/src/commands.c
+++ b/src/commands.c
@@ -409,8 +409,6 @@ csr_sign_answer *send_csrsign_command(const unsigned char *csr, const char *ttl)
         }
     }
 
-    return csr_sign_answer;
-
 error:
     if (errormsg)
     {

--- a/src/config.c
+++ b/src/config.c
@@ -36,7 +36,7 @@ int camblet_config_init()
         return -ENOMEM;
     }
 
-    strlcpy(config->trust_domain, "camblet", MAX_TRUST_DOMAIN_LEN);
+    strscpy(config->trust_domain, "camblet", MAX_TRUST_DOMAIN_LEN);
     camblet_config_unlock();
 
     return 0;

--- a/src/device_driver.c
+++ b/src/device_driver.c
@@ -210,6 +210,8 @@ wasm_vm_result load_module(const char *name, const char *code, unsigned length, 
             }
         }
 
+        result = wasm_vm_compile_module(module);
+
         wasm_vm_unlock(vm);
         wasm_vm_dump_symbols(vm);
     }

--- a/src/device_driver.c
+++ b/src/device_driver.c
@@ -359,7 +359,7 @@ static int load_camblet_config(const char *data)
         if (strcmp(config->trust_domain, trust_domain) != 0)
         {
             pr_info("change trust domain # old[%s] new[%s]", config->trust_domain, trust_domain);
-            strlcpy(config->trust_domain, trust_domain, MAX_TRUST_DOMAIN_LEN);
+            strscpy(config->trust_domain, trust_domain, MAX_TRUST_DOMAIN_LEN);
         }
         camblet_config_unlock();
     }

--- a/src/sd.c
+++ b/src/sd.c
@@ -135,8 +135,9 @@ static void service_discovery_table_free_locked(service_discovery_table *table)
         return;
 
     service_discovery_entry *entry;
+    struct hlist_node *tmp;
     int i;
-    hash_for_each(table->htable, i, entry, node)
+    hash_for_each_safe(table->htable, i, tmp, entry, node)
     {
         pr_debug("delete entry # address[%s]", entry->address);
         sd_table_entry_del_locked(entry);

--- a/src/socket.c
+++ b/src/socket.c
@@ -349,7 +349,7 @@ static bool is_bearssl(camblet_socket *s)
 
 static bool is_ktls(camblet_socket *s)
 {
-	return s->recvmsg && s->recvmsg == s->ktls_recvmsg;
+	return s->recvmsg && s->recvmsg == ktls_recvmsg;
 }
 
 static void camblet_socket_free(camblet_socket *s)

--- a/src/socket.c
+++ b/src/socket.c
@@ -1484,15 +1484,20 @@ static int handle_cert_gen_locked(camblet_socket *sc)
 	csr_sign_answer *csr_sign_answer;
 	csr_sign_answer = send_csrsign_command(csr_ptr, sc->opa_socket_ctx.ttl);
 	if (IS_ERR(csr_sign_answer))
+	{
+		kfree(csr_ptr);
 		return PTR_ERR(csr_sign_answer);
+	}
 	if (csr_sign_answer->error)
 	{
 		pr_err("error during CSR signing # err[%s]", csr_sign_answer->error);
+		kfree(csr_ptr);
 		x509_certificate_put(csr_sign_answer->cert);
 		csr_sign_answer_free(csr_sign_answer);
 		return -1;
 	}
 
+	kfree(csr_ptr);
 	x509_certificate_get(csr_sign_answer->cert);
 	sc->cert = csr_sign_answer->cert;
 	csr_sign_answer_free(csr_sign_answer);

--- a/src/task_context.c
+++ b/src/task_context.c
@@ -56,11 +56,13 @@ task_context *get_task_context(void)
     context->namespace_ids.time = current->nsproxy->time_ns->ns.inum;
     context->namespace_ids.cgroup = current->nsproxy->cgroup_ns->ns.inum;
 
+    rcu_read_lock();
     struct css_set *cset = task_css_set(current);
     if (cset)
     {
         cgroup_path(cset->dfl_cgrp, context->cgroup_path, sizeof(context->cgroup_path));
     }
+    rcu_read_unlock();
 
     return context;
 }


### PR DESCRIPTION
## Description

[some fixes on fedora (and kernel 6.8)](https://github.com/cisco-open/camblet-driver/pull/219/commits/1b924934af7156d8750f0605011aab04c5160a89)

[fix rcu locking](https://github.com/cisco-open/camblet-driver/pull/219/commits/869038a7be9df11aad28ca97c4665a1515228ab2)

[sd: fix broken removing iteration](https://github.com/cisco-open/camblet-driver/pull/219/commits/17eba7bd947810fa498b7a9e009ac5ea5833da10)

[pre-compile modules after loading](https://github.com/cisco-open/camblet-driver/pull/219/commits/062299139cbbcc486ce6accb6cb97a6c3dca63e0)

[proxywasm leak fixes](https://github.com/cisco-open/camblet-driver/pull/219/commits/581ee6e53566f8a6a68da336d7b464b28d7fa961)

[point to rebased wasm3](https://github.com/cisco-open/camblet-driver/pull/219/commits/4b29103dd75cc6fe17468a849a13148d7c5b8118)

[augmentation: fix task_context leak](https://github.com/cisco-open/camblet-driver/pull/219/commits/df7adde46147a6a221b934aa1b65b3d914de376a)

[commands: fix json object leak](https://github.com/cisco-open/camblet-driver/pull/219/commits/a9c6487d224ab07969c4e74574294d453b85854c)

[fix is_ktls detection (caused leaks)](https://github.com/cisco-open/camblet-driver/pull/219/commits/f6cff04315fe5d688abbef23288d35c2d0230ff9)

[fix csr_ptr leak](https://github.com/cisco-open/camblet-driver/pull/219/commits/6f9403f02156cc76438e0c2187a40305bea54bc6)

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
