### PR TITLE
fix proxywasm leaks

### DIFF
--- a/include/proxywasm.h
+++ b/include/proxywasm.h
@@ -86,7 +86,9 @@ proxywasm *proxywasm_for_vm(wasm_vm *vm);
 proxywasm *this_cpu_proxywasm(void);
 void proxywasm_lock(proxywasm *p, proxywasm_context *c);
 void proxywasm_unlock(proxywasm *p);
+proxywasm_context *proxywasm_get_context(proxywasm *p);
 void proxywasm_set_context(proxywasm *p, proxywasm_context *context);
+void free_proxywasms(void);
 
 wasm_vm_result init_proxywasm_for(wasm_vm *vm, wasm_vm_module *module);
 
@@ -99,8 +101,6 @@ wasm_vm_result proxy_on_upstream_connection_close(proxywasm *p, PeerType peer_ty
 
 wasm_vm_result proxywasm_create_context(proxywasm *p, buffer_t *upstream_buffer, buffer_t *downstream_buffer);
 wasm_vm_result proxywasm_destroy_context(proxywasm *p);
-
-proxywasm_context *proxywasm_get_context(proxywasm *p);
 
 // set_property_v is convenience funtion for setting a property on a context, with simple C string paths,
 // use the '.' as delimiter, those will be replaced to a '0' delimiter

--- a/src/device_driver.c
+++ b/src/device_driver.c
@@ -210,7 +210,9 @@ wasm_vm_result load_module(const char *name, const char *code, unsigned length, 
             }
         }
 
-        result = wasm_vm_compile_module(module);
+        // since for proxywasm we don't expose a lot of host functions required for compilation
+        if (strstr(name, PROXY_WASM) == NULL)
+            result = wasm_vm_compile_module(module);
 
         wasm_vm_unlock(vm);
         wasm_vm_dump_symbols(vm);

--- a/src/main.c
+++ b/src/main.c
@@ -43,8 +43,9 @@ MODULE_PARM_DESC(ktls_available, "Marks if kTLS is available on the system");
 typedef struct camblet_init_status
 {
     bool wasm;
-    bool wasm_opa;
     bool wasm_csr;
+    bool wasm_opa;
+    bool wasm_proxywasm;
     bool chardev;
     bool socket;
     bool sd_table;
@@ -136,6 +137,7 @@ static int __init camblet_init(void)
             goto out;
         }
     }
+    __camblet_init_status.wasm_proxywasm = true;
 
     result = load_module("csr_module", csr_wasm, csr_wasm_len, NULL);
     if (result.err)
@@ -144,7 +146,6 @@ static int __init camblet_init(void)
         ret = -1;
         goto out;
     }
-
     __camblet_init_status.wasm_csr = true;
 
     result = load_module("socket_opa", socket_wasm, socket_wasm_len, NULL);
@@ -154,7 +155,6 @@ static int __init camblet_init(void)
         ret = -1;
         goto out;
     }
-
     __camblet_init_status.wasm_opa = true;
 
 out:

--- a/src/socket.c
+++ b/src/socket.c
@@ -2325,6 +2325,7 @@ void socket_exit(void)
 
 	free_augmentation_cache();
 	free_cert_cache();
+	free_proxywasms();
 
 	pr_info("socket support unloaded");
 }

--- a/src/wasm.c
+++ b/src/wasm.c
@@ -497,6 +497,7 @@ wasm_vm_result wasm_vm_compile_module(wasm_vm_module *module)
     M3Result result = m3_CompileModule(module);
     if (result)
     {
+        pr_err("wasm_vm_compile_module: %s", wasm_vm_last_error(module));
         return (wasm_vm_result){.err = result};
     }
     return wasm_vm_ok;


### PR DESCRIPTION
## Description

- free proxywasm instances on exit
- log compile errors, but don't fully compile proxywasm modules (pre-compile)
- also implementing get nanoseconds in proxywasm

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [x] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
