### PR TITLE
Do not remove ktls module during test

### DIFF
--- a/test/test_helper/common.bash
+++ b/test/test_helper/common.bash
@@ -29,7 +29,6 @@ _run_kernel_modul() {
         sudo modprobe camblet dyndbg==_ ktls_available=1
     else
         echo '# Running tests with non-ktls' >&3
-        sudo rmmod tls
         sudo modprobe camblet dyndbg==_ ktls_available=0
     fi
 }


### PR DESCRIPTION
## Description
Leave the ktls module alone, after finishing testing with it. Maybe other tools are using it which blocks removing.

## Type of Change

- [X] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)
