### PR TITLE
fix class_create compile error on red hat linux

### DIFF
--- a/src/device_driver.c
+++ b/src/device_driver.c
@@ -66,7 +66,7 @@ int chardev_init(void)
 
     pr_info("char device registered # major[%d]", major);
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 4, 0)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 4, 0) && !defined(RHEL_RELEASE)
     cls = class_create(THIS_MODULE, DEVICE_NAME);
 #else
     cls = class_create(DEVICE_NAME);


### PR DESCRIPTION
## Description

Red Hat based Linux distros use an esoteric signature for this function compared to mainline kernel.

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
