### PR TITLE
Do not use relative path inside attention job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Generate artifact attestation for deb and rpm packages
         uses: actions/attest-build-provenance@v1
         with:
-          subject-path: '../camblet-driver_*.deb, rpmbuild/RPMS/noarch/camblet-driver-*.rpm'
+          subject-path: '${{ github.workspace }}/../camblet-driver_*.deb, ${{ github.workspace }}/rpmbuild/RPMS/noarch/camblet-driver-*.rpm'
 
       - name: Release
         uses: ncipollo/release-action@v1


### PR DESCRIPTION
Do not use a relative path inside the attestation job.